### PR TITLE
* Remove host-health from the 'hosts' table as it wasn't needed, give…

### DIFF
--- a/Anvil/Tools.pm
+++ b/Anvil/Tools.pm
@@ -1215,6 +1215,7 @@ sub _set_paths
 				vgscan				=>	"/usr/sbin/vgscan",
 				wc				=>	"/usr/bin/wc",
 				wget				=>	"/usr/bin/wget",
+				yum				=>	"/usr/bin/yum",
 			},
 			json			=>	{
 				all_status			=>	"all_status.json",

--- a/Anvil/Tools/Database.pm
+++ b/Anvil/Tools/Database.pm
@@ -2598,7 +2598,6 @@ Each anonymous hash is structured as:
  host_type     => $host_type, 
  host_key      => $host_key, 
  host_ipmi     => $host_ipmi, 
- host_health   => $host_health, 
  host_status   => $host_status,
  modified_date => $modified_date, 
 
@@ -2608,7 +2607,6 @@ It also sets the variables;
  hosts::host_uuid::<host_uuid>::host_type   = <host_type; node, dr or dashboard>
  hosts::host_uuid::<host_uuid>::host_key    = <Machine's public key / fingerprint, set to DELETED when the host is no longer used>
  hosts::host_uuid::<host_uuid>::host_ipmi   = <If equiped, this is how to log into the host's IPMI BMC, including the password!>
- hosts::host_uuid::<host_uuid>::host_health = <A numeric score representing the health of the node; 0 == healthy and the higher the number, the worse its health>
  hosts::host_uuid::<host_uuid>::host_status = <This is the power state of the host. Default is 'unknown', and can be "powered off", "online", "stopping" and "booting.>
  hosts::host_uuid::<host_uuid>::anvil_name  = <anvil_name if associated with an anvil>
  hosts::host_uuid::<host_uuid>::anvil_uuid  = <anvil_uuid if associated with an anvil>
@@ -2657,7 +2655,6 @@ SELECT
     host_type, 
     host_key, 
     host_ipmi, 
-    host_health, 
     host_status, 
     modified_date 
 FROM 
@@ -2686,16 +2683,14 @@ WHERE
 		my $host_type     = defined $row->[2] ? $row->[2] : "";
 		my $host_key      = defined $row->[3] ? $row->[3] : "";
 		my $host_ipmi     =         $row->[4];
-		my $host_health   =         $row->[5];
-		my $host_status   =         $row->[6];
-		my $modified_date =         $row->[7];
+		my $host_status   =         $row->[5];
+		my $modified_date =         $row->[6];
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 			host_uuid     => $host_uuid, 
 			host_name     => $host_name, 
 			host_type     => $host_type, 
 			host_key      => $host_key, 
 			host_ipmi     => $host_ipmi =~ /passw/ ? $anvil->Log->is_secure($host_ipmi) : $host_ipmi, 
-			host_health   => $host_health, 
 			host_status   => $host_status, 
 			modified_date => $modified_date, 
 		}});
@@ -2715,7 +2710,6 @@ WHERE
 			host_type     => $host_type, 
 			host_key      => $host_key, 
 			host_ipmi     => $host_ipmi, 
-			host_health   => $host_health, 
 			host_status   => $host_status, 
 			modified_date => $modified_date, 
 		};
@@ -2729,7 +2723,6 @@ WHERE
 		$anvil->data->{hosts}{host_uuid}{$host_uuid}{host_type}       = $host_type;
 		$anvil->data->{hosts}{host_uuid}{$host_uuid}{host_key}        = $host_key;
 		$anvil->data->{hosts}{host_uuid}{$host_uuid}{host_ipmi}       = $host_ipmi;
-		$anvil->data->{hosts}{host_uuid}{$host_uuid}{host_health}     = $host_health;
 		$anvil->data->{hosts}{host_uuid}{$host_uuid}{host_status}     = $host_status;
 		$anvil->data->{hosts}{host_uuid}{$host_uuid}{anvil_name}      = $anvil_name;
 		$anvil->data->{hosts}{host_uuid}{$host_uuid}{anvil_uuid}      = $anvil_uuid;
@@ -2739,7 +2732,6 @@ WHERE
 			"hosts::host_uuid::${host_uuid}::host_type"       => $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_type}, 
 			"hosts::host_uuid::${host_uuid}::host_key"        => $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_key}, 
 			"hosts::host_uuid::${host_uuid}::host_ipmi"       => $host_ipmi =~ /passw/ ? $anvil->Log->is_secure($anvil->data->{hosts}{host_uuid}{$host_uuid}{host_ipmi}) : $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_ipmi}, 
-			"hosts::host_uuid::${host_uuid}::host_health"     => $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_health}, 
 			"hosts::host_uuid::${host_uuid}::host_status"     => $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_status}, 
 			"hosts::host_uuid::${host_uuid}::anvil_name"      => $anvil->data->{hosts}{host_uuid}{$host_uuid}{anvil_name}, 
 			"hosts::host_uuid::${host_uuid}::anvil_uuid"      => $anvil->data->{hosts}{host_uuid}{$host_uuid}{anvil_uuid}, 
@@ -2786,7 +2778,6 @@ SELECT
     host_type, 
     host_key, 
     host_ipmi, 
-    host_health, 
     host_status 
 FROM 
     hosts
@@ -2806,29 +2797,25 @@ FROM
 		my $host_type   = $row->[2];
 		my $host_key    = $row->[3];
 		my $host_ipmi   = $row->[4];
-		my $host_health = $row->[5];
-		my $host_status = $row->[6];
+		my $host_status = $row->[5];
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 			host_uuid   => $host_uuid, 
 			host_name   => $host_name, 
 			host_type   => $host_type, 
 			host_key    => $host_key, 
 			host_ipmi   => $anvil->Log->is_secure($host_ipmi), 
-			host_health => $host_health, 
 			host_status => $host_status, 
 		}});
 		$anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_name}   = $host_name;
 		$anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_type}   = $host_type;
 		$anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_key}    = $host_key;
 		$anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_ipmi}   = $host_ipmi;
-		$anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_health} = $host_health;
 		$anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_status} = $host_status;
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 			"machine::host_uuid::${host_uuid}::hosts::host_name"   => $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_name}, 
 			"machine::host_uuid::${host_uuid}::hosts::host_type"   => $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_type}, 
 			"machine::host_uuid::${host_uuid}::hosts::host_key"    => $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_key}, 
 			"machine::host_uuid::${host_uuid}::hosts::host_ipmi"   => $anvil->Log->is_secure($anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_ipmi}), 
-			"machine::host_uuid::${host_uuid}::hosts::host_health" => $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_health}, 
 			"machine::host_uuid::${host_uuid}::hosts::host_status" => $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_status}, 
 		}});
 		
@@ -6815,12 +6802,6 @@ This default value is the value returned by C<< Get->host_type >>.
 
 The default value is the host's UUID (as returned by C<< Get->host_uuid >>.
 
-=head3 host_health (optional, default 'no_change')
-
-This is a numerical representation of the health of the node. C<< 0 >> is healthy, and the higher the value, the more "sick" the node is. This guides ScanCore is determining when to proactive live migrate servers.
-
-B<< Note >>: This can be set to C<< no_change >> and the existing value is left as it is.
-
 =head3 host_status (optional, default 'no_change')
 
 This is the power state of the host. Valid values are;
@@ -6850,7 +6831,6 @@ sub insert_or_update_hosts
 	my $host_name   = defined $parameter->{host_name}   ? $parameter->{host_name}   : $anvil->Get->host_name;
 	my $host_type   = defined $parameter->{host_type}   ? $parameter->{host_type}   : $anvil->Get->host_type;
 	my $host_uuid   = defined $parameter->{host_uuid}   ? $parameter->{host_uuid}   : $anvil->Get->host_uuid;
-	my $host_health = defined $parameter->{host_health} ? $parameter->{host_health} : "no_change";
 	my $host_status = defined $parameter->{host_status} ? $parameter->{host_status} : "no_change";
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 		uuid        => $uuid, 
@@ -6861,7 +6841,6 @@ sub insert_or_update_hosts
 		host_name   => $host_name, 
 		host_type   => $host_type, 
 		host_uuid   => $host_uuid, 
-		host_health => $host_health, 
 		host_status => $host_status, 
 	}});
 	
@@ -6891,7 +6870,6 @@ sub insert_or_update_hosts
 	my $old_host_name   = "";
 	my $old_host_type   = "";
 	my $old_host_key    = "";
-	my $old_host_health = ""; 
 	my $old_host_status = "";
 	my $query           = "
 SELECT 
@@ -6899,7 +6877,6 @@ SELECT
     host_name, 
     host_type, 
     host_key, 
-    host_health, 
     host_status 
 FROM 
     hosts 
@@ -6920,22 +6897,15 @@ WHERE
 		$old_host_name   = $row->[1];
 		$old_host_type   = $row->[2];
 		$old_host_key    = $row->[3];
-		$old_host_health = $row->[4]; 
-		$old_host_status = $row->[5];
+		$old_host_status = $row->[4];
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => {
 			old_host_ipmi   => $old_host_ipmi =~ /passw/ ? $anvil->Log->is_secure($old_host_ipmi) : $old_host_ipmi,
 			old_host_name   => $old_host_name, 
 			old_host_type   => $old_host_type, 
 			old_host_key    => $old_host_key, 
-			old_host_health => $old_host_health, 
 			old_host_status => $old_host_status, 
 		}});
 		
-		if ($host_health eq "no_change")
-		{
-			$host_health = $old_host_health;
-			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { host_health => $host_health }});
-		}
 		if ($host_status eq "no_change")
 		{
 			$host_status = $old_host_status;
@@ -6945,7 +6915,6 @@ WHERE
 	if (not $count)
 	{
 		# Add this host to the database
-		my $say_host_health = $host_health eq "no_change" ? 0         : $host_health;
 		my $say_host_status = $host_status eq "no_change" ? "unknown" : $host_status;
 		my $query           = "
 INSERT INTO 
@@ -6956,7 +6925,6 @@ INSERT INTO
     host_type, 
     host_key, 
     host_ipmi, 
-    host_health, 
     host_status,  
     modified_date
 ) VALUES (
@@ -6965,7 +6933,6 @@ INSERT INTO
     ".$anvil->Database->quote($host_type).",
     ".$anvil->Database->quote($host_key).",
     ".$anvil->Database->quote($host_ipmi).",
-    ".$anvil->Database->quote($say_host_health).",
     ".$anvil->Database->quote($say_host_status).",
     ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
 );
@@ -6976,7 +6943,6 @@ INSERT INTO
 	elsif (($old_host_name   ne $host_name)   or 
 	       ($old_host_type   ne $host_type)   or 
 	       ($old_host_key    ne $host_key)    or 
-	       ($old_host_health ne $host_health) or 
 	       ($old_host_status ne $host_status))
 	{
 		# Clear the stop data.
@@ -6988,7 +6954,6 @@ SET
     host_type     = ".$anvil->Database->quote($host_type).", 
     host_key      = ".$anvil->Database->quote($host_key).", 
     host_ipmi     = ".$anvil->Database->quote($host_ipmi).", 
-    host_health   = ".$anvil->Database->quote($host_health).", 
     host_status   = ".$anvil->Database->quote($host_status).", 
     modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
 WHERE
@@ -14519,6 +14484,7 @@ sub resync_databases
 	{
 		# We don't sync 'states' as it's transient and sometimes per-DB.
 		next if $table eq "states";
+		next if $table eq "oui";
 		
 		# If the 'schema' is 'public', there is no table in the history schema. If there is a host 
 		# column, the resync will be restricted to entries from this host uuid.
@@ -15246,7 +15212,7 @@ sub _archive_table
 	}
 	
 	# We don't archive the OUI table, it generally has more entries than needed to trigger the archive, but it's needed.
-	if ($table eq "oui")
+	if (($table eq "oui") or ($table eq "states"))
 	{
 		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, priority => "err", key => "log_0459", variables => { table => $table }});
 		return(0);
@@ -15561,8 +15527,9 @@ sub _find_behind_databases
 		# behind and a resync will be needed.
 		foreach my $table (@{$anvil->data->{sys}{database}{check_tables}})
 		{
-			# We don't sync 'states' as it's transient and sometimes per-DB.
+			# We don't sync 'states' or 'oui' as it's transient and sometimes per-DB.
 			next if $table eq "states";
+			next if $table eq "oui";
 			
 			# Does this table exist yet?
 			my $query = "SELECT COUNT(*) FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND table_schema = 'public' AND table_name = ".$anvil->Database->quote($table).";";
@@ -15689,6 +15656,7 @@ ORDER BY
 	{
 		# We don't sync 'states' as it's transient and sometimes per-DB.
 		next if $table eq "states";
+		next if $table eq "oui";
 		
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 			"sys::database::table::${table}::last_updated" => $anvil->data->{sys}{database}{table}{$table}{last_updated}, 

--- a/Anvil/Tools/Get.pm
+++ b/Anvil/Tools/Get.pm
@@ -1808,19 +1808,23 @@ sub os_type
 	
 	### NOTE: Examples;
 	# Red Hat Enterprise Linux release 8.0 Beta (Ootpa)
-	# Red Hat Enterprise Linux Server release 7.5 (Maipo)
-	# CentOS Linux release 7.5.1804 (Core) 
-
+	# CentOS Stream release 8
+	
+	### NOTE: This can be called before 'rsync' is called, so we use 'cat'
 	# Read in the /etc/redhat-release file
-	my $release = $anvil->Storage->read_file({
+	my ($release, $error, $return_code) = $anvil->Remote->call({
 		debug       => $debug, 
-		file        => $anvil->data->{path}{data}{'redhat-release'},
+		shell_call  => $anvil->data->{path}{exe}{cat}." ".$anvil->data->{path}{data}{'redhat-release'}, 
 		port        => $port, 
 		password    => $password, 
 		remote_user => $remote_user, 
 		target      => $target,
 	});
-	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { release => $release }});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		release     => $release,
+		error       => $error,
+		return_code => $return_code, 
+	}});
 	if ($release =~ /Red Hat Enterprise Linux .* (\d+)\./)
 	{
 		# RHEL, with the major version number appended
@@ -1839,7 +1843,7 @@ sub os_type
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { os_type => $os_type }});
 	}
 	
-	my ($output, $return_code) = $anvil->System->call({shell_call => $anvil->data->{path}{exe}{uname}." --hardware-platform"});
+	(my $output, $return_code) = $anvil->System->call({shell_call => $anvil->data->{path}{exe}{uname}." --hardware-platform"});
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { output => $output, return_code => $return_code }});
 	if ($output)
 	{

--- a/Anvil/Tools/ScanCore.pm
+++ b/Anvil/Tools/ScanCore.pm
@@ -646,7 +646,6 @@ sub post_scan_analysis_striker
 		my $host_type   = $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_type};
 		my $host_key    = $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_key};
 		my $host_ipmi   = $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_ipmi};
-		my $host_health = $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_health}; 
 		my $host_status = $anvil->data->{machine}{host_uuid}{$host_uuid}{hosts}{host_status};
 		my $password    = $anvil->data->{machine}{host_uuid}{$host_uuid}{password};
 		my $anvil_name  = $anvil->data->{machine}{host_uuid}{$host_uuid}{anvil}{name};
@@ -657,7 +656,6 @@ sub post_scan_analysis_striker
 			host_type   => $host_type, 
 			host_key    => $host_key, 
 			host_ipmi   => $anvil->Log->is_secure($host_ipmi), 
-			host_health => $host_health, 
 			host_status => $host_status, 
 			password    => $anvil->Log->is_secure($password), 
 			anvil_name  => $anvil_name, 

--- a/notes
+++ b/notes
@@ -1,3 +1,10 @@
+TODO: 
+- Remove this; (step 2) "This is the user name that you will log into Striker as and the name of the user that owns the database"
+- Being set to the gateway, not the default DNS - "This is the domain name server(s) to use when resolving domain names. You can specify 2 or more, separated by commas."
+- The web UI password isn't being set properly during Striker stage-2 setup
+- Changing the password doesn't log out active webui sessions.
+- host_health is a duplicate of 'health'
+
 ============
 
 DISABLE KSM! 
@@ -702,3 +709,59 @@ resource srv01-sql {
         }
 }
 ==================
+
+mediawiki on EL8 install notes (starting from a minimal install);
+
+dnf module reset php
+dnf module enable php:7.4
+dnf install httpd php php-mysqlnd php-gd php-xml mariadb-server mariadb php-mbstring php-json \
+            vim postgresql-server postgresql-plperl bash-completion wget tar rsync mlocate php-pecl-apcu \
+            memcached php-pear icu php-intl php-pgsql bzip2 
+
+postgresql-setup --initdb
+systemctl start postgresql.service 
+systemctl enable postgresql.service 
+systemctl start httpd.service 
+systemctl enable httpd.service 
+systemctl start memcached.service
+systemctl enable memcached.service
+firewall-cmd --permanent --zone=public --add-service=http
+firewall-cmd --permanent --zone=public --add-service=https
+systemctl restart firewalld
+
+
+# diff -u /var/lib/pgsql/data/pg_hba.conf.orig /var/lib/pgsql/data/pg_hba.conf
+====
+--- /var/lib/pgsql/data/pg_hba.conf.orig	2021-02-17 02:50:10.959000000 -0500
++++ /var/lib/pgsql/data/pg_hba.conf	2021-02-17 02:52:54.859000000 -0500
+@@ -77,11 +77,12 @@
+ # TYPE  DATABASE        USER            ADDRESS                 METHOD
+ 
+ # "local" is for Unix domain socket connections only
+-local   all             all                                     peer
++local   all             postgres                                ident
++local   all             all                                     md5
+ # IPv4 local connections:
+-host    all             all             127.0.0.1/32            ident
++host    all             all             127.0.0.1/32            md5
+ # IPv6 local connections:
+-host    all             all             ::1/128                 ident
++host    all             all             ::1/128                 md5
+ # Allow replication connections from localhost, by a user with the
+ # replication privilege.
+ local   replication     all                                     peer
+====
+ 
+# diff -u /etc/php.ini.orig /etc/php.ini
+====
+--- /etc/php.ini.orig	2021-02-17 02:56:32.293000000 -0500
++++ /etc/php.ini	2021-02-17 02:57:33.731000000 -0500
+@@ -903,6 +903,7 @@
+ ; 'extension='php_<ext>.dll') is supported for legacy reasons and may be
+ ; deprecated in a future PHP major version. So, when it is possible, please
+ ; move to the new ('extension=<ext>) syntax.
++extension=php_pgsql.so
+ 
+ ;;;;
+ ; Note: packaged extension modules are now loaded via the .ini files
+====

--- a/share/anvil.sql
+++ b/share/anvil.sql
@@ -3,7 +3,7 @@
 -- The line below is used by machines in the Anvil! to know if their software version is compatible with the
 -- database servers. As such, do NOT edit the line below unless you know why you're changing it.
 -- - Version follows: https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
--- SchemaVersion: 0.0.1
+-- SchemaVersion: 0.0.2
 -- 
 -- It expects PostgreSQL v. 9.1+
 --
@@ -55,7 +55,6 @@ CREATE TABLE hosts (
     host_type        text                        not null,                         -- Either 'node' or 'dashboard' or 'dr'. It is left empty until the host is configured.
     host_key         text                        not null,                         -- This is the host's key used to authenticate it when other machines try to ssh to it.
     host_ipmi        text                        not null    default '',           -- This is an optional string, in 'fence_ipmilan' format, that tells how to access/fence this host.
-    host_health      numeric                     not null    default 0,            -- This is a numerical representation of the health of the node. 0 is healthy, and the higher the value, the more "sick" the node is. This guides ScanCore is determining when to proactive live migrate servers.
     host_status      text                        not null    default 'unknown',    -- This is the power state of the host. Default is 'unknown', and can be "powered off", "online", "stopping" and "booting.
     modified_date    timestamp with time zone    not null
 );
@@ -68,7 +67,6 @@ CREATE TABLE history.hosts (
     host_type        text,
     host_key         text,
     host_ipmi        text,
-    host_health      numeric,
     host_status      text,
     modified_date    timestamp with time zone    not null
 );
@@ -86,7 +84,6 @@ BEGIN
          host_type, 
          host_key, 
          host_ipmi, 
-         host_health, 
          host_status, 
          modified_date)
     VALUES
@@ -95,7 +92,6 @@ BEGIN
          history_hosts.host_type,
          history_hosts.host_key, 
          history_hosts.host_ipmi, 
-         history_hosts.host_health, 
          history_hosts.host_status, 
          history_hosts.modified_date);
     RETURN NULL;

--- a/share/words.xml
+++ b/share/words.xml
@@ -665,6 +665,7 @@ It should be provisioned in the next minute or two.</key>
 		<key name="job_0221">The server: [#!variable!server_name!#] was not found in the cluster configuration. This can happen if a server was partially deleted and we're trying again.</key>
 		<key name="job_0222">Preparing to delete the server: [#!variable!server_name!#].</key>
 		<key name="job_0223">Using virsh to destroy (force off) the server: [#!variable!server_name!#], if it is still running.</key>
+		<key name="job_0224">Enabled the HA repository for CentOS Stream.</key>
 		
 		<!-- Log entries -->
 		<key name="log_0001">Starting: [#!variable!program!#].</key>

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -876,7 +876,7 @@ sub run_jobs
 	my $jobs_file = "{\"jobs\":[\n";
 	
 	# Get a list of pending or incomplete jobs.
-	my $return = $anvil->Database->get_jobs({debug => 2, ended_within => 300});
+	my $return = $anvil->Database->get_jobs({debug => 3, ended_within => 300});
 	my $count  = @{$return};
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
 		'return' => $return, 
@@ -897,7 +897,7 @@ sub run_jobs
 		my $job_status          = $hash_ref->{job_status};
 		my $started_seconds_ago = $job_picked_up_at ? (time - $job_picked_up_at) : 0;
 		my $updated_seconds_ago = $job_updated      ? (time - $job_updated)      : 0;
-		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
 			job_uuid            => $job_uuid,
 			job_command         => $job_command,
 			job_data            => $job_data,

--- a/tools/striker-auto-initialize-all
+++ b/tools/striker-auto-initialize-all
@@ -1,0 +1,94 @@
+#!/usr/bin/perl
+# 
+# NOTE: This tool is NOT meant for production use! It is meant as a tool for CI/CD testing. 
+# 
+# If this is used for any other purpose, it is at he user's own risk. Please be sure to thoroughly test the 
+# resulting Anvil! before going into production (which, honestly, you should do anyways).
+# 
+
+use strict;
+use warnings;
+use Anvil::Tools;
+use Data::Dumper;
+
+$| = 1;
+
+my $THIS_FILE           =  ($0 =~ /^.*\/(.*)$/)[0];
+my $running_directory   =  ($0 =~ /^(.*?)\/$THIS_FILE$/)[0];
+if (($running_directory =~ /^\./) && ($ENV{PWD}))
+{
+	$running_directory =~ s/^\./$ENV{PWD}/;
+}
+
+=cut 
+
+Striker initialization;
+            variable_uuid             |                  variable_name                   |     variable_value      | variable_default | variable_description | variable_section |         variable_source_uuid         | variable_source_table |         modified_date         
+--------------------------------------+--------------------------------------------------+-------------------------+------------------+----------------------+------------------+--------------------------------------+-----------------------+-------------------------------
+ b397973f-e871-4140-baab-6d77611b4edd | form::config_step1::organization::value          | Alteeve                 |                  | striker_0004         | config_step1     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:26:22.938934-05
+ 55261634-0495-448f-a41f-24af7ed57911 | form::config_step1::prefix::value                | di                      |                  | striker_0006         | config_step1     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:26:22.938934-05
+ 192d3636-3e66-46cb-bf60-5e11c35220dc | form::config_step1::domain::value                | digimer.ca              |                  | striker_0008         | config_step1     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:26:22.938934-05
+ e53cc9f3-6d8e-4622-8b56-7df8b90cdd24 | form::config_step1::ifn_count::value             | 1                       |                  | striker_0012         | config_step1     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:26:22.938934-05
+ 823222e7-e55a-48e6-8b16-cf2046c880b4 | form::config_step1::sequence::value              | 2                       |                  | striker_0010         | config_step1     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:27:39.491016-05
+
+ 858c40b8-6612-4922-b824-1eb6ce3c74cc | form::config_step2::host_name::value             | di-striker02.digimer.ca |                  | striker_0017         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:29:59.317812-05
+ 9a176810-403b-4180-b502-90a8529c43bd | form::config_step2::striker_user::value          | admin                   |                  | striker_0032         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:29:59.317812-05
+ 8bdf6cc8-3799-4759-8e7d-7d9ebbc74d6a | form::config_step2::striker_password::value      | super secret password   |                  | striker_0034         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:29:59.317812-05
+ 0c22eba6-438a-4a7d-8a4b-c473e24da790 | form::config_step2::dns::value                   | 8.8.8.8, 8.8.4.4        |                  | striker_0038         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:29:59.317812-05
+ cd443969-30ee-45ca-a189-8546e945dd13 | form::config_step2::bcn1_ip::value               | 10.201.4.2              |                  | striker_0024         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:29:59.317812-05
+ 8f618047-59e9-4d56-b842-ea6e43c6aac1 | form::config_step2::bcn1_subnet_mask::value      | 255.255.0.0             |                  | striker_0025         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:29:59.317812-05
+ 7b6d2213-3852-42d2-9a3c-f31f2197c6b2 | form::config_step2::bcn1_link1_mac_to_set::value | 52:54:00:8b:d6:82       |                  | striker_0029         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:29:59.317812-05
+ a1137f58-22c3-4d12-bfbd-1f88c1cb0956 | form::config_step2::ifn1_subnet_mask::value      | 255.255.255.0           |                  | striker_0025         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:29:59.317812-05
+ 52842c37-4f8b-4d77-9712-c911d4abaf11 | form::config_step2::ifn1_link1_mac_to_set::value | 52:54:00:c0:f2:7c       |                  | striker_0029         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:29:59.317812-05
+ 42f33705-8fbb-48eb-82cf-e0ec2f2cfebe | form::config_step2::ifn1_ip::value               | 192.168.122.12          |                  | striker_0024         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:30:16.688974-05
+ 7110e4e9-6cc7-4a9b-a0c8-8e234ab3fbc9 | form::config_step2::gateway::value               | 192.168.122.1           |                  | striker_0036         | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:30:16.688974-05
+ 7efc6c79-4806-478e-ae55-b9d09e2f23aa | form::config_step2::gateway_interface::value     | ifn1                    |                  |                      | config_step2     | a64c477b-b0a1-4985-9968-f4b46d75fb0c | hosts                 | 2021-02-16 20:30:16.688974-05
+
+anvil=# SELECT * FROM jobs WHERE job_uuid = '158e8384-eac7-4289-8f70-bc43eaf8b017';
+               job_uuid               |            job_host_uuid             |          job_command           |      job_data      | job_picked_up_by | job_picked_up_at | job_updated |      job_name      | job_progress | job_title | job_description | job_status |         m
+odified_date         
+--------------------------------------+--------------------------------------+--------------------------------+--------------------+------------------+------------------+-------------+--------------------+--------------+-----------+-----------------+------------+----------
+---------------------
+ 158e8384-eac7-4289-8f70-bc43eaf8b017 | a64c477b-b0a1-4985-9968-f4b46d75fb0c | /usr/sbin/anvil-configure-host | form::config_step2 |                0 |                0 |  1613525509 | configure::network |            0 | job_0001  | job_0002        |            | 2021-02-1
+6 20:31:49.108908-05
+
+
+# At this point, the Striker should be coming up at the IP. Once both/all Strikers are up, update their anvil.conf to add each other's UUID database entry.
+# FROM ONE STRIKER;
+               job_uuid               |            job_host_uuid             |                                                         job_command                                                          |                                                                   job_data                                                                    | job_picked_up_by | job_picked_up_at | job_updated |     job_name      | job_progress | job_title | job_description | job_status |         modified_date         
+--------------------------------------+--------------------------------------+------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+------------------+------------------+-------------+-------------------+--------------+-----------+-----------------+------------+-------------------------------
+ 6ca30d0b-c03c-43f9-bd7c-c40a79ca52a8 | 46c00674-fea2-44af-981d-2833d5c8270a | /usr/sbin/striker-manage-peers --add --host-uuid a64c477b-b0a1-4985-9968-f4b46d75fb0c --host 10.201.4.2 --port 5432 --ping 1 | password=super secret password                                                                                                               +|                0 |                0 |  1613699163 | striker-peer::add |            0 | job_0011  | job_0012        |            | 2021-02-18 20:46:03.305568-05
+                                      |                                      |                                                                                                                              | peer_job_command=/usr/sbin/striker-manage-peers --add --host-uuid 46c00674-fea2-44af-981d-2833d5c8270a --host 10.201.4.1 --port 5432 --ping 1 |                  |                  |             |                   |              |           |                 |            | 
+(1 row)
+
+# Initialize nodes / dr hosts (may need to call striker-get-peer-data)
+anvil=# SELECT * FROM jobs ;
+               job_uuid               |            job_host_uuid             |            job_command            |            job_data             | job_picked_up_by | job_picked_up_at | job_updated |             job_name              | job_progress | job_title | job_description | job_status |        modified_date         
+--------------------------------------+--------------------------------------+-----------------------------------+---------------------------------+------------------+------------------+-------------+-----------------------------------+--------------+-----------+-----------------+------------+------------------------------
+ a5c3381c-c581-4020-baa0-72e136c75a68 | 46c00674-fea2-44af-981d-2833d5c8270a | /usr/sbin/striker-initialize-host | password=Initial1              +|                0 |                0 |  1613957250 | initialize::node::192.168.122.207 |            0 | job_0020  | job_0022        |            | 2021-02-21 20:27:30.73576-05
+                                      |                                      |                                   | rh_password=                   +|                  |                  |             |                                   |              |           |                 |            | 
+                                      |                                      |                                   | rh_user=                       +|                  |                  |             |                                   |              |           |                 |            | 
+                                      |                                      |                                   | host_ip_address=192.168.122.207+|                  |                  |             |                                   |              |           |                 |            | 
+                                      |                                      |                                   | ssh_port=22                    +|                  |                  |             |                                   |              |           |                 |            | 
+                                      |                                      |                                   | type=node                      +|                  |                  |             |                                   |              |           |                 |            | 
+                                      |                                      |                                   | host_name=di-a02n01.alteeve.com+|                  |                  |             |                                   |              |           |                 |            | 
+                                      |                                      |                                   |                                 |                  |                  |             |                                   |              |           |                 |            | 
+(1 row)
+
+=cut
+
+
+
+my $anvil = Anvil::Tools->new();
+
+$anvil->Database->connect;
+$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
+if (not $anvil->data->{sys}{database}{connections})
+{
+	# No databases, exit.
+	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, priority => "err", key => "error_0003"});
+	$anvil->nice_exit({exit_code => 1});
+}
+$anvil->Get->switches;
+
+$anvil->nice_exit({exit_code => 0});

--- a/tools/striker-auto-initialize-all.example
+++ b/tools/striker-auto-initialize-all.example
@@ -1,0 +1,12 @@
+# This is an example script to feed to 'striker-auto-initialize-all'.
+# 
+
+base::password::current = Initial1
+base::password::desired = super secret password
+base::organization_name = Alteeve's Niche!
+base::prefix            = an
+base::domain            = alteeve.com
+
+striker::1::network::startup_ip           = 192.168.122.145
+striker::1::network::ifn::1::ip           = 192.168.122.11
+striker::1::network::ifn::1::link::1::mac = aa:bb:cc:dd:ee:ff

--- a/tools/striker-initialize-host
+++ b/tools/striker-initialize-host
@@ -91,7 +91,7 @@ sub set_host_name
 	
 	# Try to set the host name now.
 	my ($host_name, $descriptive_host_name) = $anvil->System->host_name({
-		debug       => 2, 
+		debug       => 3, 
 		set         => $anvil->data->{data}{host_name},
 		password    => $anvil->data->{data}{password}, 
 		port        => $anvil->data->{data}{ssh_port}, 
@@ -382,10 +382,12 @@ EOF
 		update_progress($anvil, $anvil->data->{job}{progress}, "job_0030");
 		
 		# We'll attach subscriptions if this is set
-		my $subscribe = 1;
+		my $subscribe  = 1;
+		my $shell_call = $anvil->data->{path}{exe}{'subscription-manager'}." identity";
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
 		my ($output, $error, $return_code) = $anvil->Remote->call({
-			debug       => 2,
-			shell_call  => $anvil->data->{path}{exe}{'subscription-manager'}." identity", 
+			debug       => 3,
+			shell_call  => $shell_call, 
 			password    => $anvil->data->{data}{password}, 
 			port        => $anvil->data->{data}{ssh_port}, 
 			target      => $anvil->data->{data}{host_ip_address},
@@ -411,9 +413,11 @@ EOF
 			update_progress($anvil, $anvil->data->{job}{progress}, "job_0033");
 			my $bash_password =  $anvil->data->{data}{rh_password};
 			   $bash_password =~ s/'/\\\'/g;
+			my $shell_call = $anvil->data->{path}{exe}{'subscription-manager'}." register --username ".$anvil->data->{data}{rh_user}." --password '".$bash_password."' --auto-attach --force";
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
 			my ($output, $error, $return_code) = $anvil->Remote->call({
-				debug       => 2,
-				shell_call  => $anvil->data->{path}{exe}{'subscription-manager'}." register --username ".$anvil->data->{data}{rh_user}." --password '".$bash_password."' --auto-attach --force",
+				debug       => 3,
+				shell_call  => $shell_call,
 				password    => $anvil->data->{data}{password}, 
 				port        => $anvil->data->{data}{ssh_port}, 
 				target      => $anvil->data->{data}{host_ip_address},
@@ -480,9 +484,12 @@ EOF
 			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, 'print' => 1, key => "job_0036", variables => { repo => 'codeready-builder-for-rhel-8-x86_64-rpms' }});
 			$anvil->data->{job}{progress} += 5;
 			update_progress($anvil, $anvil->data->{job}{progress}, "job_0036,!!repo!codeready-builder-for-rhel-8-x86_64-rpms!!");
+			
+			my $shell_call = $anvil->data->{path}{exe}{'subscription-manager'}." repos --enable codeready-builder-for-rhel-8-x86_64-rpms";
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
 			my ($output, $error, $return_code) = $anvil->Remote->call({
 				debug       => 3,
-				shell_call  => $anvil->data->{path}{exe}{'subscription-manager'}." repos --enable codeready-builder-for-rhel-8-x86_64-rpms",
+				shell_call  => $shell_call,
 				password    => $anvil->data->{data}{password}, 
 				port        => $anvil->data->{data}{ssh_port}, 
 				target      => $anvil->data->{data}{host_ip_address},
@@ -502,9 +509,12 @@ EOF
 				$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, 'print' => 1, key => "job_0036", variables => { repo => 'rhel-8-for-x86_64-highavailability-rpms' }});
 				$anvil->data->{job}{progress} += 5;
 				update_progress($anvil, $anvil->data->{job}{progress}, "job_0036,!!repo!rhel-8-for-x86_64-highavailability-rpms!!");
+				
+				my $shell_call = $anvil->data->{path}{exe}{'subscription-manager'}." repos --enable rhel-8-for-x86_64-highavailability-rpms";
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
 				my ($output, $error, $return_code) = $anvil->Remote->call({
 					debug       => 3,
-					shell_call  => $anvil->data->{path}{exe}{'subscription-manager'}." repos --enable rhel-8-for-x86_64-highavailability-rpms",
+					shell_call  => $shell_call,
 					password    => $anvil->data->{data}{password}, 
 					port        => $anvil->data->{data}{ssh_port}, 
 					target      => $anvil->data->{data}{host_ip_address},
@@ -527,9 +537,12 @@ EOF
 			undef $output;
 			undef $error;
 			undef $return_code;
+			undef $shell_call;
+			$shell_call = $anvil->data->{path}{exe}{'subscription-manager'}." repos --list-enabled";
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
 			($output, $error, $return_code) = $anvil->Remote->call({
 				debug       => 3,
-				shell_call  => $anvil->data->{path}{exe}{'subscription-manager'}." repos --list-enabled",
+				shell_call  => $shell_call,
 				password    => $anvil->data->{data}{password}, 
 				port        => $anvil->data->{data}{ssh_port}, 
 				target      => $anvil->data->{data}{host_ip_address},
@@ -567,6 +580,40 @@ EOF
 		}
 	}
 	
+	# If this is a CentOS Stream OS, enable the HA repo.
+	my ($os_type, $os_arch) = $anvil->Get->os_type({
+		debug    => 2,
+		password => $anvil->data->{data}{password}, 
+		port     => $anvil->data->{data}{ssh_port}, 
+		target   => $anvil->data->{data}{host_ip_address},
+	});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		os_type => $os_type, 
+		os_arch => $os_arch, 
+	}});
+	if ($os_type =~ /centos-stream/)
+	{
+		# Enable the HA repo
+		my $shell_call = $anvil->data->{path}{exe}{yum}." config-manager --set-enabled ha";
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+		my ($output, $error, $return_code) = $anvil->Remote->call({
+			debug       => 3, 
+			shell_call  => $shell_call, 
+			password    => $anvil->data->{data}{password}, 
+			port        => $anvil->data->{data}{ssh_port}, 
+			target      => $anvil->data->{data}{host_ip_address},
+			remote_user => "root",
+		});
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			error       => $error,
+			output      => $output,
+			return_code => $return_code, 
+		}});
+		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, 'print' => 1, key => "job_0224"});
+		$anvil->data->{job}{progress} += 2;
+		update_progress($anvil, $anvil->data->{job}{progress}, "job_0224");
+	}
+	
 	### NOTE: This seems dumb without internet, but it's worth calling anyway in case the repo on the 
 	###       Striker has newer packages. If we go right to installing packages and one of them is newer
 	###       than an installed dependency, the install could fail. This prevents that.
@@ -577,9 +624,12 @@ EOF
 	update_progress($anvil, $anvil->data->{job}{progress}, "job_0040");
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, key => "job_0039"});
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, key => "job_0040"});
+	
+	my $shell_call = $anvil->data->{path}{exe}{'dnf'}." -y update";
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
 	my ($output, $error, $return_code) = $anvil->Remote->call({
 		debug       => 3,
-		shell_call  => $anvil->data->{path}{exe}{'dnf'}." -y update",
+		shell_call  => $shell_call,
 		password    => $anvil->data->{data}{password}, 
 		port        => $anvil->data->{data}{ssh_port}, 
 		target      => $anvil->data->{data}{host_ip_address},
@@ -599,9 +649,12 @@ EOF
 	undef $output;
 	undef $error;
 	undef $return_code;
+	undef $shell_call;
+	$shell_call = $anvil->data->{path}{exe}{'dnf'}." -y remove biosdevname";
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
 	($output, $error, $return_code) = $anvil->Remote->call({
 		debug       => 3,
-		shell_call  => $anvil->data->{path}{exe}{'dnf'}." -y remove biosdevname",
+		shell_call  => $shell_call,
 		password    => $anvil->data->{data}{password}, 
 		port        => $anvil->data->{data}{ssh_port}, 
 		target      => $anvil->data->{data}{host_ip_address},
@@ -624,9 +677,12 @@ EOF
 	undef $output;
 	undef $error;
 	undef $return_code;
+	undef $shell_call;
+	$shell_call = $anvil->data->{path}{exe}{'dnf'}." -y install ".$package;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
 	($output, $error, $return_code) = $anvil->Remote->call({
 		debug       => 3,
-		shell_call  => $anvil->data->{path}{exe}{'dnf'}." -y install ".$package,
+		shell_call  => $shell_call,
 		password    => $anvil->data->{data}{password}, 
 		port        => $anvil->data->{data}{ssh_port}, 
 		target      => $anvil->data->{data}{host_ip_address},
@@ -645,9 +701,12 @@ EOF
 	undef $output;
 	undef $error;
 	undef $return_code;
+	undef $shell_call;
+	$shell_call = $anvil->data->{path}{exe}{'dnf'}." list installed ".$package;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
 	($output, $error, $return_code) = $anvil->Remote->call({
-		debug       => 2,
-		shell_call  => $anvil->data->{path}{exe}{'dnf'}." list installed ".$package,
+		debug       => 3,
+		shell_call  => $shell_call,
 		password    => $anvil->data->{data}{password}, 
 		port        => $anvil->data->{data}{ssh_port}, 
 		target      => $anvil->data->{data}{host_ip_address},


### PR DESCRIPTION
…n the 'health' table. Bumped the SQL version to 0.0.2

* Updated Get->os_type() to use 'cat' instead of Storage->read_file() because 'rsync' may not be available when it is called during striker-initialize-host calls.
* Updated Database methods to skip 'oui' and 'state' during resync.
* Updatedb striker-initialize-host to detect when it's initializing a CentOS Stream Node / DR Host and enable the HA repo.
* Created the tools/striker-auto-initialize-all tool, which is very much incomplete, that will allow for the rapid creation of a full Anvil! from freshly installed machines autonomously.

Signed-off-by: Digimer <digimer@alteeve.ca>