### PR TITLE
* Added a check to Database->get_ip_addresses() to check is a hash is…

### DIFF
--- a/Anvil/Tools/Database.pm
+++ b/Anvil/Tools/Database.pm
@@ -3067,17 +3067,17 @@ AND
 			
 			# Which device is it on?
 			my $on_interface = "";
-			if ($ip_address_on_type eq "bridge")
+			if (($ip_address_on_type eq "bridge") && (defined $anvil->data->{hosts}{host_uuid}{$host_uuid}{bridges}{bridge_uuid}{$ip_address_on_uuid}{bridge_name}))
 			{
 				$on_interface = $anvil->data->{hosts}{host_uuid}{$host_uuid}{bridges}{bridge_uuid}{$ip_address_on_uuid}{bridge_name};
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { on_interface => $on_interface }});
 			}
-			elsif ($ip_address_on_type eq "bond")
+			elsif (($ip_address_on_type eq "bond") && (defined $anvil->data->{hosts}{host_uuid}{$host_uuid}{bonds}{bond_uuid}{$ip_address_on_uuid}{bond_name}))
 			{
 				$on_interface = $anvil->data->{hosts}{host_uuid}{$host_uuid}{bonds}{bond_uuid}{$ip_address_on_uuid}{bond_name};
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { on_interface => $on_interface }});
 			}
-			elsif ($ip_address_on_type eq "interface")
+			elsif (($ip_address_on_type eq "interface") && (defined $anvil->data->{hosts}{host_uuid}{$host_uuid}{network_interfaces}{network_interface_uuid}{$ip_address_on_uuid}{network_interface_name}))
 			{
 				$on_interface = $anvil->data->{hosts}{host_uuid}{$host_uuid}{network_interfaces}{network_interface_uuid}{$ip_address_on_uuid}{network_interface_name};
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { on_interface => $on_interface }});

--- a/Anvil/Tools/Remote.pm
+++ b/Anvil/Tools/Remote.pm
@@ -957,6 +957,8 @@ sub test_access
 		shell_call  => $anvil->data->{path}{exe}{echo}." 1", 
 		target      => $target,
 		remote_user => $user, 
+		'close'     => 1,
+		no_cache    => 1,
 	});
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 		output      => $output,

--- a/share/words.xml
+++ b/share/words.xml
@@ -341,6 +341,7 @@ Output (if any):
 		<key name="error_0247">The variable: [#!variable!variable!#] is invalid: [#!variable!value!#].</key>
 		<key name="error_0248">Failed to add the UPS: [#!variable!ups_name!#] at: [#!variable!aups_ip_address!#] using the agent: [#!variable!ups_agent!#]!</key>
 		<key name="error_0249">Failed to add the fence device: [#!variable!fence_name!#] using the agent: [#!variable!fence_agent!#]!</key>
+		<key name="error_0250">This machine is a an active cluster member, aborting job.</key>
 		
 		<!-- Files templates -->
 		<!-- NOTE: Translating these files requires an understanding of which likes are translatable -->

--- a/tools/anvil-configure-host
+++ b/tools/anvil-configure-host
@@ -10,6 +10,7 @@
 # 4 = The host name did not update properly.
 # 5 = Failed to write the temp file with the new password needed to call anvil-change-password.
 # 6 = The job-uuid was not found.
+# 7 = The host is an active cluster member.
 # 
 # TODO: 
 # - Add MTU support
@@ -35,6 +36,8 @@ my $anvil = Anvil::Tools->new();
 
 # Read switches
 $anvil->Get->switches;
+$anvil->Log->level({set => 2});
+$anvil->Log->secure({set => 1});
 
 # Make sure we're running as 'root'
 # $< == real UID, $> == effective UID
@@ -176,7 +179,7 @@ sub reconfigure_network
 	my $ifn_count        = exists $anvil->data->{variables}{form}{config_step1}{ifn_count}{value}    ? $anvil->data->{variables}{form}{config_step1}{ifn_count}{value}    : 1;
 	my $new_host_name    = exists $anvil->data->{variables}{form}{config_step2}{host_name}{value}    ? $anvil->data->{variables}{form}{config_step2}{host_name}{value}    : "";
 	my $type             = $anvil->Get->host_type();
-	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, secure => 0, list => { 
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, list => { 
 		prefix        => $prefix, 
 		sequence      => $sequence,
 		domain        => $domain, 
@@ -667,6 +670,7 @@ sub reconfigure_network
 					
 					if (-e $old_link1_file)
 					{
+						$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, 'print' => 1, key => "log_0589", variables => { file => $old_link1_file }});
 						unlink $old_link1_file;
 					}
 				}
@@ -695,6 +699,7 @@ sub reconfigure_network
 					sleep 1;
 					if (-e $old_link2_file)
 					{
+						$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, 'print' => 1, key => "log_0589", variables => { file => $old_link2_file }});
 						unlink $old_link2_file;
 					}
 				}
@@ -1198,6 +1203,21 @@ AND
 		message  => "message_0015", 
 		job_uuid => $anvil->data->{job}{uuid},
 	});
+	
+	# If we're in a cluster, abort.
+	my ($problem) = $anvil->Cluster->parse_cib();
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { problem => $problem }});
+	if ((not $problem) && ($anvil->data->{cib}{parsed}{'local'}{ready}))
+	{
+		# We're in a cluster, abort.
+		$anvil->Job->update_progress({
+			progress => 100, 
+			message  => "error_0250", 
+			job_uuid => $anvil->data->{job}{uuid},
+		});
+		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, key => "error_0250"});
+		$anvil->nice_exit({exit_code => 7});
+	}
 	
 	return(0);
 }

--- a/tools/anvil-join-anvil
+++ b/tools/anvil-join-anvil
@@ -37,6 +37,8 @@ my $anvil = Anvil::Tools->new();
 # Read switches (target ([user@]host[:port]) and the file with the target's password. If the password is 
 # passed directly, it will be used. Otherwise, the password will be read from the database.
 $anvil->Get->switches;
+$anvil->Log->level({set => 2});
+$anvil->Log->secure({set => 1});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0115", variables => { program => $THIS_FILE }});
 
 $anvil->Database->connect();
@@ -756,7 +758,9 @@ sub configure_pacemaker
 					}});
 					
 					# Ignore 'delay', we handle that in Cluster->set_delay();
-					if (($argument ne "pcmk_off_action") && ($anvil->data->{fence_data}{$fence_agent}{switch}{$argument}{name} eq "delay"))
+					if (($argument ne "pcmk_off_action")                                           && 
+					    (exists $anvil->data->{fence_data}{$fence_agent}{switch}{$argument}{name}) && 
+					    ($anvil->data->{fence_data}{$fence_agent}{switch}{$argument}{name} eq "delay"))
 					{
 						next;
 					}
@@ -1029,6 +1033,7 @@ sub configure_pacemaker
 	}
 	
 	# Enable fencing and set the retry to INFINITY, if needed.
+	$anvil->data->{cib}{parsed}{data}{stonith}{'max-attempts'} = "" if not defined $anvil->data->{cib}{parsed}{data}{stonith}{'max-attempts'};
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 		"cib::parsed::data::stonith::max-attempts" => $anvil->data->{cib}{parsed}{data}{stonith}{'max-attempts'}, 
 	}});
@@ -1689,7 +1694,7 @@ sub check_local_network
 			's2:current_mtu' => $current_mtu,
 		}});
 		
-		if ($current_mtu eq $mtu)
+		if (($mtu) && ($current_mtu eq $mtu))
 		{
 			# It's fine
 			update_progress($anvil, ($anvil->data->{job}{progress} += 2), "job_0087,!!interface!".$in_iface."!!,!!mtu!".$mtu."!!");

--- a/tools/striker-auto-initialize-all
+++ b/tools/striker-auto-initialize-all
@@ -35,6 +35,8 @@ if (not $anvil->data->{sys}{database}{connections})
 $anvil->data->{switches}{config}     = "";
 $anvil->data->{switches}{'job-uuid'} = "";
 $anvil->Get->switches;
+$anvil->Log->level({set => 2});
+$anvil->Log->secure({set => 1});
 
 # Read in the config file
 if ((not $anvil->data->{switches}{config}) or (not -f $anvil->data->{switches}{config}))
@@ -367,6 +369,7 @@ sub configure_machine_networks
 					}});
 					
 					my $access = $anvil->Remote->test_access({
+						debug    => 2,
 						target   => $bcn1_ip,
 						password => $anvil->data->{base}{password}{startup},
 					});
@@ -377,6 +380,7 @@ sub configure_machine_networks
 						# Try again with the new password, in case it's already 
 						# updated.
 						my $access = $anvil->Remote->test_access({
+							debug    => 2,
 							target   => $bcn1_ip,
 							password => $anvil->data->{base}{password}{desired},
 						});

--- a/tools/striker-auto-initialize-all.example
+++ b/tools/striker-auto-initialize-all.example
@@ -51,7 +51,7 @@ base::rhn::password     =
 ###       required!
 striker::1::network::ifn::1::ip           = 192.168.122.251
 striker::1::network::ifn::1::subnet_mask  = 255.255.255.0
-striker::1::network::ifn::1::link::1::mac = 52:54:00:df:03:e
+striker::1::network::ifn::1::link::1::mac = 52:54:00:df:03:e3
 striker::1::network::ifn::1::link::2::mac = 52:54:00:45:6e:5d
 striker::1::network::bcn::1::ip           = 10.201.4.1
 striker::1::network::bcn::1::subnet_mask  = 255.255.0.0

--- a/tools/striker-initialize-host
+++ b/tools/striker-initialize-host
@@ -33,6 +33,8 @@ my $anvil = Anvil::Tools->new();
 # Read switches (target ([user@]host[:port]) and the file with the target's password.
 $anvil->data->{switches}{'job-uuid'} = "";
 $anvil->Get->switches;
+$anvil->Log->level({set => 2});
+$anvil->Log->secure({set => 1});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0115", variables => { program => $THIS_FILE }});
 $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 	'switches::job-uuid' => $anvil->data->{switches}{'job-uuid'},
@@ -670,6 +672,7 @@ EOF
 	# In the CI, we'll have custom repos installed. So here we're looking to see if 'anvil-X' is already 
 	# installed. If so, we won't add our repo.
 	my $anvil_role_rpm = "";
+	my $alteeve_repo   = 0;
 	undef $output;
 	undef $error;
 	undef $return_code;
@@ -685,27 +688,37 @@ EOF
 		remote_user => "root", 
 		timeout     => 300,
 	});
-	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
 		output      => $output, 
 		error       => $error, 
 		return_code => $return_code,
 	}});
 	foreach my $line (split/\n/, $output)
 	{
+		next if $line =~ /Installed Packages/i;
 		$line =~ s/\s.*$//;
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { line => $line }});
 		
 		next if $line =~ /anvil-core/;
+		if ($line =~ /alteeve.*repo.noarch/)
+		{
+			$alteeve_repo = 1;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { alteeve_repo => $alteeve_repo }});
+		}
 		if ($line =~ /anvil-(.*).noarch/)
 		{
 			$anvil_role_rpm = $1;
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { anvil_role_rpm => $anvil_role_rpm }});
-			last;
 		}
+		last if $anvil_role_rpm && $alteeve_repo;
 	}
 	
 	# Install the Alteeve repo, if possible. There may be no Internet access, so it's OK if this fails.
-	if (not -e $anvil->data->{path}{config}{'alteeve-el8.repo'})
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		alteeve_repo   => $alteeve_repo,
+		anvil_role_rpm => $anvil_role_rpm,
+	}});
+	if (not $alteeve_repo)
 	{
 		if ($anvil_role_rpm)
 		{


### PR DESCRIPTION
… set before using it, to help avoid unitialized variable messages.

* Updated Remote->test_access() to not used cached SSH access.
* Updated anvil-configure-host to abort if the host is in a cluster.
* Updated anvil-join-anvil to clean up some variable checks to help avoid unitialized variable messages.
* Updated striker-initialize-host to check if an anvil RPM is installed and, if so, not install the Anvil! repo.

Signed-off-by: Digimer <digimer@alteeve.ca>