### PR TITLE
* Updated Database->manage_anvil_conf() to not manually create a back…

### DIFF
--- a/Anvil/Tools/Database.pm
+++ b/Anvil/Tools/Database.pm
@@ -13878,19 +13878,7 @@ sub manage_anvil_conf
 	
 	if ($rewrite)
 	{
-		# Backup the original
-		my $backup_file = $anvil->Storage->backup({
-			debug       => 2,
-			secure      => 1, 
-			file        => $anvil->data->{path}{configs}{'anvil.conf'},
-			password    => $password, 
-			port        => $port, 
-			remote_user => $remote_user, 
-			target      => $target,
-		});
-		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { backup_file => $backup_file }});
-		
-		# Now update!
+		# Now update! This will back up the file as well.
 		my ($failed) = $anvil->Storage->write_file({
 			debug       => $debug,
 			secure      => 1, 
@@ -13908,7 +13896,7 @@ sub manage_anvil_conf
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { failed => $failed }});
 		if ($failed)
 		{
-			# Something went weong.
+			# Something went wrong.
 			return(1);
 		}
 		

--- a/Anvil/Tools/Storage.pm
+++ b/Anvil/Tools/Storage.pm
@@ -3936,7 +3936,8 @@ fi";
 					my $temp_file =  $file;
 					   $temp_file =~ s/\//_/g;
 					   $temp_file =~ s/^_//g;
-					   $temp_file = "/tmp/".$temp_file;
+					   $temp_file =  "/tmp/".$temp_file;
+					   $temp_file .= ".".$anvil->Get->uuid({debug => $debug, short => 1});
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { temp_file => $temp_file }});
 					$anvil->Storage->write_file({
 						body      => $body,
@@ -3968,6 +3969,11 @@ fi";
 					{
 						# Something went wrong writing it.
 						$error = 1;
+						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { error => $error }});
+						$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "warning_0081", variables => { 
+							temp_file => $temp_file, 
+							target    => $remote_user."\@".$target.":".$file,
+						}});
 					}
 				}
 			}

--- a/notes
+++ b/notes
@@ -9,7 +9,10 @@ TODO:
 
 Jenkins;
 
-- 
+Initial setup:
+export NODE_NAME=anvil-ci-bm
+export python=python3
+./ci-update-yum
 
 ============
 

--- a/share/words.xml
+++ b/share/words.xml
@@ -2321,6 +2321,7 @@ Read UUID: .... [#!variable!read_uuid!#]
 		<key name="warning_0078">[ Warning ] - Not installing the Alteeve repo! The package: [#!variable!anvil_role_rpm!#] is already installed. This is OK, but be aware that updates from Alteeve will not be available. To change this, please install: [#!variable!alteeve_repo!#].</key>
 		<key name="warning_0079">[ Warning ] - Failed to read the JSON formatted output of 'lsblk'. Expected the return code '0' but received: [#!variable!return_code!#]. The output, if any, was: [#!variable!output!#].</key>
 		<key name="warning_0080">[ Warning ] - Failed to read the XML formatted output of 'lshw'. Expected the return code '0' but received: [#!variable!return_code!#]. The output, if any, was: [#!variable!output!#].</key>
+		<key name="warning_0081">[ Warning ] - The temporary file: [#!variable!temp_file!#] vanished (or failed to be created) before it could be copied to: [#!variable!target!#].</key>
 
 		<!-- The entries below here are not sequential, but use a key to find the entry. -->
 		<!-- Run 'striker-parse-os-list to find new entries. --> 


### PR DESCRIPTION
…up, as Storage->write_file() creates a backup anyway (so we were getting two backups per one change).

* Updated Storage->write_file() to add a short UUID suffix to the temp file before rsync'ing to the target to help avoid source temp file name collisions in parallel running copies to different targets.

Signed-off-by: Digimer <digimer@alteeve.ca>