### PR TITLE
* Updated DRBD->gather_data() to check if drbdadm exists before tryin…

### DIFF
--- a/Anvil/Tools/Database.pm
+++ b/Anvil/Tools/Database.pm
@@ -14616,7 +14616,7 @@ sub resync_databases
 				$query .= " WHERE ".$host_column." = ".$anvil->Database->quote($anvil->data->{sys}{host_uuid});
 			}
 			$query .= " ORDER BY utc_modified_date DESC;";
-			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => $debug, key => "log_0074", variables => { uuid => $anvil->data->{database}{$uuid}{host}, query => $query }});
+			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => $debug, key => "log_0074", variables => { uuid => $uuid, query => $query }});
 			
 			my $results = $anvil->Database->query({uuid => $uuid, query => $query, source => $THIS_FILE, line => __LINE__});
 			my $count   = @{$results};
@@ -15729,7 +15729,7 @@ ORDER BY
 				###       the difference is more than 10 seconds.
 				# Resync needed.
 				my $difference = $anvil->data->{sys}{database}{table}{$table}{last_updated} - $anvil->data->{sys}{database}{table}{$table}{uuid}{$uuid}{last_updated};
-				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 					"s1:difference"                                                  => $anvil->Convert->add_commas({number => $difference }), 
 					"s2:sys::database::table::${table}::last_updated"                => $anvil->data->{sys}{database}{table}{$table}{last_updated}, 
 					"s3:sys::database::table::${table}::uuid::${uuid}::last_updated" => $anvil->data->{sys}{database}{table}{$table}{uuid}{$uuid}{last_updated}, 

--- a/scancore-agents/Makefile.am
+++ b/scancore-agents/Makefile.am
@@ -31,6 +31,14 @@ dist_drbd_DATA			= \
 dist_drbd_SCRIPTS		= \
 				  scan-drbd/scan-drbd
 
+filesystemsdir                  = ${targetdir}/scan-filesystems
+dist_filesystems_DATA           = \
+                                  scan-filesystems.xml \
+                                  scan-filesystems.sql
+
+dist_filesystems_SCRIPTS        = \
+                                  scan-filesystems
+
 hardwaredir			= ${targetdir}/scan-hardware
 dist_hardware_DATA		= \
 				  scan-hardware/scan-hardware.xml \

--- a/scancore-agents/scan-drbd/scan-drbd.xml
+++ b/scancore-agents/scan-drbd/scan-drbd.xml
@@ -18,19 +18,7 @@ NOTE: All string keys MUST be prefixed with the agent name! ie: 'scan_server_log
 		
 		<!-- Error entries -->
 		<key name="scan_drbd_error_0001">DRBD is not configured on this host, exiting.</key>
-		<key name="scan_drbd_error_0002">The call to 'drbdadm dump-xml' returned the exit code: [#!variable!return_code!#].</key>
-		<key name="scan_drbd_error_0003">[ Warning ] - Failed to parse the DRBD XML. The XML read was:
-========
-#!variable!xml!#
-========
-
-The error was:
-
-========
-#!variable!error!#
-========
-		</key>
-		
+			
 		<!-- Error entries -->
 		<key name="scan_drbd_log_0001">Starting The: [#!variable!program!#] DRBD resource agent.</key>
 		

--- a/scancore-agents/scan-ipmitool/scan-ipmitool
+++ b/scancore-agents/scan-ipmitool/scan-ipmitool
@@ -877,11 +877,13 @@ INSERT INTO
     scan_ipmitool_values 
 (
     scan_ipmitool_value_uuid, 
+    scan_ipmitool_value_host_uuid, 
     scan_ipmitool_value_scan_ipmitool_uuid, 
     scan_ipmitool_value_sensor_value, 
     modified_date
 ) VALUES (
     ".$anvil->Database->quote($scan_ipmitool_value_uuid).", 
+    ".$anvil->Database->quote($anvil->Get->host_uuid).",
     ".$anvil->Database->quote($scan_ipmitool_uuid).",
     ".$anvil->Database->quote($new_scan_ipmitool_value_sensor_value).",  
     ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."

--- a/scancore-agents/scan-ipmitool/scan-ipmitool.sql
+++ b/scancore-agents/scan-ipmitool/scan-ipmitool.sql
@@ -78,6 +78,7 @@ CREATE TRIGGER trigger_scan_ipmitool
 -- possible.
 CREATE TABLE scan_ipmitool_values (
     scan_ipmitool_value_uuid                  uuid                        not null    primary key,
+    scan_ipmitool_value_host_uuid             uuid                        not null,
     scan_ipmitool_value_scan_ipmitool_uuid    uuid                        not null,
     scan_ipmitool_value_sensor_value          numeric                     not null,
     modified_date                             timestamp with time zone    not null,
@@ -89,6 +90,7 @@ ALTER TABLE scan_ipmitool_values OWNER TO admin;
 CREATE TABLE history.scan_ipmitool_values (
     history_id                                uuid,
     scan_ipmitool_value_uuid                  uuid,
+    scan_ipmitool_value_host_uuid             uuid,
     scan_ipmitool_value_scan_ipmitool_uuid    uuid,
     scan_ipmitool_value_sensor_value          numeric,
     modified_date                             timestamp with time zone    not null
@@ -103,11 +105,13 @@ BEGIN
     SELECT INTO history_scan_ipmitool_values * FROM scan_ipmitool_values WHERE scan_ipmitool_value_uuid=new.scan_ipmitool_value_uuid;
     INSERT INTO history.scan_ipmitool_values 
         (scan_ipmitool_value_uuid,
+         scan_ipmitool_value_host_uuid, 
          scan_ipmitool_value_scan_ipmitool_uuid, 
          scan_ipmitool_value_sensor_value, 
          modified_date)
     VALUES
         (history_scan_ipmitool_values.scan_ipmitool_value_uuid,
+         history_scan_ipmitool_values.scan_ipmitool_value_host_uuid, 
          history_scan_ipmitool_values.scan_ipmitool_value_scan_ipmitool_uuid, 
          history_scan_ipmitool_values.scan_ipmitool_value_sensor_value, 
          history_scan_ipmitool_values.modified_date);

--- a/share/anvil.sql
+++ b/share/anvil.sql
@@ -22,7 +22,11 @@
 -- 
 -- NOTE: If you have a column that is '<table>_host_uuid', and it's role is to show which host a moveable
 --       thing is on (as opposed to a record bound to a host_uuid), be sure to add the table name to the
---       excluded list in Database->_find_behind_databases().
+--       excluded list in Database->_find_behind_databases(). 
+-- 
+-- NOTE: When developing Scan Agents; If an agent's data is tied to a host, all tables in the SQL schema for
+--       that agent need to also be tied to the host so that resyncs of sub tables don't sync when they
+--       shouldn't.
 -- 
 -- Most tables will want to have a matching table in the history schema with an additional 
 -- 'history_id  bigserial' column. Match the function and trigger seen elsewhere to copy your data from the
@@ -31,8 +35,6 @@
 -- If a table is a child of another table, ie: a UPS battery is a child of a UPS, and you have tables for 
 -- each that you plan to link, still use a '*_host_uuid' column (if the data is host-specific). This is 
 -- needed by the resync method.
--- 
--- NOTE: If you add, rename or remove a table, remember to update the 'sys::database::core_tables' array!
 -- 
 
 

--- a/share/words.xml
+++ b/share/words.xml
@@ -342,6 +342,19 @@ Output (if any):
 		<key name="error_0248">Failed to add the UPS: [#!variable!ups_name!#] at: [#!variable!aups_ip_address!#] using the agent: [#!variable!ups_agent!#]!</key>
 		<key name="error_0249">Failed to add the fence device: [#!variable!fence_name!#] using the agent: [#!variable!fence_agent!#]!</key>
 		<key name="error_0250">This machine is a an active cluster member, aborting job.</key>
+		<key name="error_0251">We were asked to call 'drbdadm' but it doesn't exist. Is DRBD installed?</key>
+		<key name="error_0252">The call to 'drbdadm dump-xml' returned the exit code: [#!variable!return_code!#].</key>
+		<key name="error_0253">[ Warning ] - Failed to parse the DRBD XML. The XML read was:
+========
+#!variable!xml!#
+========
+
+The error was:
+
+========
+#!variable!error!#
+========
+		</key>
 		
 		<!-- Files templates -->
 		<!-- NOTE: Translating these files requires an understanding of which likes are translatable -->

--- a/tools/scancore
+++ b/tools/scancore
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # 
-# This is the main ScanCore program. It is started/killed/recovered by anvil-daemon.
+# This is the main ScanCore program. It is managed by systemd
 # 
 # Examples;
 # 


### PR DESCRIPTION
…g to call it to avoid scary errors in the logs. Also moved some strings that pulled from the scan-drbd agent into the main words file.

* Fixed a bug in ScanCore->agent_startup() where a (thankfully broken) check to append tables to the 'sys::database::check_tables' would cause an infinite loop as both were pointers to the same anonymous array.
* Fixed a bug in scan-ipmitool where the scan_ipmitool_variables table didn't use a host_uuid reference, causing resyncs of that table to sync for all hosts and cause DB errors when the scan_ipmitool record from another host wasn't sync'ed yet.

Signed-off-by: Digimer <digimer@alteeve.ca>