### PR TITLE
The theme of these commits is improving DB responsiveness.

### DIFF
--- a/Anvil/Tools.pm
+++ b/Anvil/Tools.pm
@@ -839,6 +839,11 @@ sub _set_defaults
 			# Delay between scans?
 			run_interval			=>	30,
 		},
+		database			=>	{
+			# This is the number of hours, after which, transient data (like temperature and 
+			# power data) is considered "old" and gets deleted from the database.
+			age_out				=>	48,
+		},
 	};
 	$anvil->data->{sys} = {
 		apache				=>	{

--- a/Anvil/Tools/ScanCore.pm
+++ b/Anvil/Tools/ScanCore.pm
@@ -154,10 +154,7 @@ sub agent_startup
 	}
 	
 	# Connect to DBs.
-	$anvil->Database->connect({
-		debug     => $debug,
-		no_resync => 0,
-	});
+	$anvil->Database->connect({debug => $debug});
 	$anvil->Log->entry({source => $agent, line => __LINE__, level => $debug, secure => 0, key => "log_0132"});
 	if (not $anvil->data->{sys}{database}{connections})
 	{
@@ -197,7 +194,6 @@ sub agent_startup
 	}
 	
 	return(0);
-	
 }
 
 

--- a/scancore-agents/scan-ipmitool/scan-ipmitool.sql
+++ b/scancore-agents/scan-ipmitool/scan-ipmitool.sql
@@ -88,7 +88,7 @@ CREATE TABLE scan_ipmitool_values (
 ALTER TABLE scan_ipmitool_values OWNER TO admin;
 
 CREATE TABLE history.scan_ipmitool_values (
-    history_id                                uuid,
+    history_id                                bigserial,
     scan_ipmitool_value_uuid                  uuid,
     scan_ipmitool_value_host_uuid             uuid,
     scan_ipmitool_value_scan_ipmitool_uuid    uuid,

--- a/share/words.xml
+++ b/share/words.xml
@@ -718,6 +718,9 @@ sys::manage::firewall						=	1
 		<key name="header_0059">Link Drops</key>
 		<key name="header_0060"><![CDATA[-=[ Bond Status - #!variable!date!# ] =-]]></key>
 		<key name="header_0061"><![CDATA[-=[ Ctrl + C to exit ] =-]]></key>
+		<key name="header_0062">Table</key>
+		<key name="header_0063">public</key>		<!-- SQL schema -->
+		<key name="header_0064">history</key>		<!-- SQL schema -->
 		
 		<!-- Strings used by jobs -->
 		<key name="job_0001">Configure Network</key>
@@ -2450,6 +2453,7 @@ If you are comfortable that the target has changed for a known reason, you can s
 		<key name="striker_0284">Cancel</key>
 		<key name="striker_0285">Close</key>
 		<key name="striker_0286">This controls if 'anvil-safe-start' is enabled on a node.</key>
+		<key name="striker_0287">The virtio NAT bridge: [#!variable!bridge!#] exists. Removing it...</key>
 		
 		<!-- These are generally units and appended to numbers -->
 		<key name="suffix_0001">#!variable!number!#/sec</key>

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -44,6 +44,7 @@ dist_sbin_SCRIPTS	= \
 			  striker-prep-database \
 			  striker-purge-target \
 			  striker-scan-network \
+			  striker-show-db-counts \
 			  striker-auto-initialize-all
 
 fencedir		= $(FASEXECPREFIX)/sbin

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -91,7 +91,7 @@ $anvil->System->_check_anvil_conf();
 
 # Connect to the database(s). If we have no connections, we'll proceed anyway as one of the 'run_once' tasks
 # is to setup the database server.
-$anvil->Database->connect({check_if_configured => 1});
+$anvil->Database->connect({check_if_configured => 1, check_for_resync => 1});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0132"});
 
 # If I have no databases, sleep for a second and then exit (systemd will restart us).

--- a/tools/anvil-join-anvil
+++ b/tools/anvil-join-anvil
@@ -1664,7 +1664,7 @@ sub check_local_network
 			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, 'print' => 1, key => "log_0464", variables => { interface => $interface_name }});
 			$anvil->System->call({debug => 3, shell_call => $anvil->data->{path}{exe}{nmcli}." connection up \"".$interface_name."\""});
 		}
-	
+		
 		# Wait for a DB connection. We'll wait up to 130 seconds (updelay is 120 seconds, plus a small buffer).
 		my $wait_until = time + 130;
 		until ($anvil->data->{sys}{database}{connections})

--- a/tools/anvil-update-states
+++ b/tools/anvil-update-states
@@ -139,6 +139,46 @@ sub update_network
 		ip        => {},
 	};
 	
+	# Make sure there are no virsh bridges, removing any found.
+	my $host_type = $anvil->Get->host_type();
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { host_type => $host_type }});
+	if (($host_type eq "node") or ($host_type eq "dr"))
+	{
+		my $shell_call = $anvil->data->{path}{exe}{virsh}." net-list --all --name";
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+		
+		my ($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			output      => $output,
+			return_code => $return_code, 
+		}});
+		foreach my $line (split/\n/, $output)
+		{
+			$line =~ s/^\s+//;
+			$line =~ s/\s+$//;
+			next if not $line;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { line => $line }});
+			
+			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, key => "striker_0287", variables => { bridge => $line }});
+			
+			my $shell_call = $anvil->data->{path}{exe}{virsh}." net-destroy ".$line;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+			my ($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				output      => $output,
+				return_code => $return_code, 
+			}});
+			
+			$shell_call = $anvil->data->{path}{exe}{virsh}." net-undefine ".$line;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+			($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				output      => $output,
+				return_code => $return_code, 
+			}});
+		}
+	}
+	
 	# Walk through the sysfs files.
 	local(*DIRECTORY);
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 3, key => "log_0018", variables => { directory => $directory }});
@@ -176,7 +216,7 @@ sub update_network
 			$duplex      =~ s/\n$//;
 			$operational =~ s/\n$//;
 			$speed       =~ s/\n$//;
-			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 				interface   => $interface, 
 				speed       => $speed, 
 				mac_address => $mac_address,
@@ -204,7 +244,7 @@ sub update_network
 				$ip_address  = defined $anvil->data->{network}{$local_host}{interface}{$interface}{ip}          ? $anvil->data->{network}{$local_host}{interface}{$interface}{ip}          : "";
 				$subnet_mask = defined $anvil->data->{network}{$local_host}{interface}{$interface}{subnet_mask} ? $anvil->data->{network}{$local_host}{interface}{$interface}{subnet_mask} : "";
 				$type        = defined $anvil->data->{network}{$local_host}{interface}{$interface}{type}        ? $anvil->data->{network}{$local_host}{interface}{$interface}{type}        : "interface";
-				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 					ip_address  => $ip_address, 
 					subnet_mask => $subnet_mask,
 					type        => $type, 
@@ -314,7 +354,7 @@ sub update_network
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { bridge_stp_enabled => $bridge_stp_enabled }});
 			}
 			
-			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 				active_interface     => $active_interface, 
 				bond_master          => $bond_master, 
 				bond_mode            => $bond_mode, 
@@ -373,7 +413,7 @@ sub update_network
 			if ($ip_address)
 			{
 				$anvil->data->{seen}{ip}{$ip_address} = $interface;
-				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { "seen::ip::${ip_address}" => $anvil->data->{seen}{ip}{$ip_address} }});
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { "seen::ip::${ip_address}" => $anvil->data->{seen}{ip}{$ip_address} }});
 			}
 			
 			# Store new information we found.
@@ -966,6 +1006,7 @@ WHERE
 		{
 			# This IP address no longer exists on this host, removing it.
 			my $ip_address_uuid = $anvil->Database->insert_or_update_ip_addresses({
+				debug           => 2,
 				file            => $THIS_FILE,
 				line            => __LINE__,
 				'delete'        => 1,

--- a/tools/scancore
+++ b/tools/scancore
@@ -18,6 +18,11 @@
 #   shutdown.
 # - Add a '--silence-alerts --anvil <name>' and '--restore-alerts --anvil <name>' to temporarily 
 #   disable/re-enable alerts. This is to allow for quiet maintenance without stopping scancore itself.
+#   
+# - Disable resync checks by default, and have a resync check happen on scancore startup, anvil-daemon 
+#   startup, and during configuration. 
+# - Delete records from temperature and power tables that are older than 48 hours, checking periodically in
+#   scancore on strikers only. Delete jobs records that are 100% complete for 48 hours or more.
 # 
 
 use strict;
@@ -142,8 +147,6 @@ while(1)
 		next;
 	}
 	
-	### TODO: Left off here 
-	###       - Agents are timing out?
 	# Send alerts.
 	$anvil->Email->send_alerts({debug => 2});
 	
@@ -240,7 +243,7 @@ sub wait_for_database
 {
 	my ($anvil) = @_;
 	
-	$anvil->Database->connect;
+	$anvil->Database->connect({check_for_resync => 1});
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0132"});
 	if (not $anvil->data->{sys}{database}{connections})
 	{
@@ -256,7 +259,7 @@ sub wait_for_database
 			$anvil->_set_paths();
 			$anvil->_set_defaults();
 			$anvil->Storage->read_config();
-			$anvil->Database->connect;
+			$anvil->Database->connect({check_for_resync => 1});
 			if ($anvil->data->{sys}{database}{connections})
 			{
 				# We're good
@@ -365,6 +368,12 @@ sub startup_tasks
 			my $say_uptime = $anvil->Convert->time({'time' => $uptime});
 			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, key => "log_0620", variables => { uptime => $say_uptime }});
 		}
+	}
+	elsif ($host_type eq "striker")
+	{
+		# We're a striker, so we're going to check for / remove transient database records on tables
+		# that always grow (temperature, power, etc) and whose data loses value as it ages.
+
 	}
 	
 	return(0);

--- a/tools/striker-manage-install-target
+++ b/tools/striker-manage-install-target
@@ -1461,6 +1461,8 @@ sub load_packages
 		}
 	}
 	
+	### TODO: Download 'alteeve-release.noarch' directly.
+	
 	### NOTE: If/when we support other archs, removing '.x86_64/.noarch' would cause all available archs 
 	###       to be downloaded (including .ix86, which would waste space...). Decide if it's best to 
 	###       explicitely declare archs vs using space/bandwidth to just grab all available.
@@ -1475,7 +1477,6 @@ sub load_packages
 			"adwaita-gtk2-theme.x86_64",
 			"adwaita-icon-theme.noarch",
 			"alsa-lib.x86_64",
-			"alteeve-release.noarch", 
 			"annobin.x86_64",
 			"anvil-core.noarch",
 			"anvil-dr.noarch",

--- a/tools/striker-show-db-counts
+++ b/tools/striker-show-db-counts
@@ -1,0 +1,160 @@
+#!/usr/bin/perl
+#
+# This shows the total number of rows in the public and history (where applicable) schemas of all available 
+# databases. It is meant as a diagnostic tool
+#
+
+use strict;
+use warnings;
+use Anvil::Tools;
+use Data::Dumper;
+
+$| = 1;
+
+my $THIS_FILE           =  ($0 =~ /^.*\/(.*)$/)[0];
+my $running_directory   =  ($0 =~ /^(.*?)\/$THIS_FILE$/)[0];
+if (($running_directory =~ /^\./) && ($ENV{PWD}))
+{
+	$running_directory =~ s/^\./$ENV{PWD}/;
+}
+
+my $anvil = Anvil::Tools->new();
+
+$anvil->Database->connect({debug => 3});
+$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
+if (not $anvil->data->{sys}{database}{connections})
+{
+	# No databases, exit.
+	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, priority => "err", key => "error_0003"});
+	$anvil->nice_exit({exit_code => 1});
+}
+$anvil->Get->switches();
+
+my $table_length = 0;
+my $count_length = 0;
+my $db_length    = 0; 
+my $tables       = $anvil->Database->get_tables_from_schema({schema_file => "all"});
+foreach my $table (@{$tables})
+{
+	if (length($table) > $table_length)
+	{
+		$table_length = length($table);
+	}
+	
+	foreach my $uuid (keys %{$anvil->data->{cache}{database_handle}})
+	{
+		$anvil->data->{counts}{$table}{$uuid}{public_count}  = 0;
+		$anvil->data->{counts}{$table}{$uuid}{history_count} = 0;
+		if ($anvil->data->{sys}{database}{history_table}{$table})
+		{
+			my $query = "SELECT COUNT(*) FROM history.".$table.";";
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { query => $query }});
+			
+			$anvil->data->{counts}{$table}{$uuid}{history_count} = $anvil->Database->query({uuid => $uuid, query => $query, source => $THIS_FILE, line => __LINE__})->[0]->[0];
+			
+			my $say_count = $anvil->Convert->add_commas({number => $anvil->data->{counts}{$table}{$uuid}{history_count}});
+			$anvil->data->{counts}{$table}{$uuid}{history_comma} = $say_count;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
+				"counts::${table}::${uuid}::history_count" => $anvil->data->{counts}{$table}{$uuid}{history_count},
+				"counts::${table}::${uuid}::history_comma" => $anvil->data->{counts}{$table}{$uuid}{history_comma},
+			}});
+			if (length($say_count) > $count_length)
+			{
+				$count_length = length($say_count);
+			}
+		}
+		else
+		{
+			$anvil->data->{counts}{$table}{$uuid}{history_count} = -1;
+			$anvil->data->{counts}{$table}{$uuid}{history_comma} = "--";
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
+				"counts::${table}::${uuid}::history_count" => $anvil->data->{counts}{$table}{$uuid}{history_count},
+				"counts::${table}::${uuid}::history_comma" => $anvil->data->{counts}{$table}{$uuid}{history_comma},
+			}});
+		}
+		my $query = "SELECT COUNT(*) FROM ".$table.";";
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { query => $query }});
+		
+		$anvil->data->{counts}{$table}{$uuid}{public_count} = $anvil->Database->query({uuid => $uuid, query => $query, source => $THIS_FILE, line => __LINE__})->[0]->[0];
+			
+		my $say_count = $anvil->Convert->add_commas({number => $anvil->data->{counts}{$table}{$uuid}{public_count}});
+		$anvil->data->{counts}{$table}{$uuid}{public_comma} = $say_count;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
+			"counts::${table}::${uuid}::public_count" => $anvil->data->{counts}{$table}{$uuid}{public_count},
+			"counts::${table}::${uuid}::public_comma" => $anvil->data->{counts}{$table}{$uuid}{public_comma},
+		}});
+		if (length($say_count) > $count_length)
+		{
+			$count_length = length($say_count);
+		}
+	}
+}
+
+$db_length = (($count_length * 2) + 3);
+foreach my $uuid (keys %{$anvil->data->{cache}{database_handle}})
+{
+	my $host_name =  $anvil->Get->host_name_from_uuid({host_uuid => $uuid});
+	   $host_name =~ s/\..*$//;
+	if (length($host_name) > $db_length) 
+	{
+		$db_length = length($host_name);
+	}
+	
+	$anvil->data->{host_uuid}{$uuid}{host_name}    = $host_name;
+	$anvil->data->{db_host_name}{$host_name}{uuid} = $uuid;
+}
+
+if ($db_length > (($count_length * 2) - 3))
+{
+	$count_length = (($db_length - 3) / 2);
+	
+	if ($count_length =~ /\./)
+	{
+		$count_length = (int($count_length) + 1);
+		$db_length++;
+	}
+}
+
+# header, line 1, and build break line
+my $break_line = "-"; for (1..$table_length) { $break_line .= "-"; };
+print " "; for (1..$table_length) { print " "; };
+foreach my $host_name (sort {$a cmp $b} keys %{$anvil->data->{db_host_name}})
+{
+	print " | ".sprintf("%-${db_length}s", $host_name);
+	$break_line .= "-+-"; for (1..$count_length) { $break_line .= "-"; };
+	$break_line .= "-+-"; for (1..$count_length) { $break_line .= "-"; };
+}
+$break_line .= "-";
+print " \n";
+
+# header, line 2
+my $say_table      = $anvil->Words->string({key => "header_0062"});
+my $say_public     = $anvil->Words->string({key => "header_0063"});
+my $say_history    = $anvil->Words->string({key => "header_0064"});
+my $center_table   = $anvil->Words->center_text({string => $say_table,   width => $table_length});
+my $center_public  = $anvil->Words->center_text({string => $say_public,  width => $count_length});
+my $center_history = $anvil->Words->center_text({string => $say_history, width => $count_length});
+print " ".$center_table;
+foreach my $host_name (sort {$a cmp $b} keys %{$anvil->data->{db_host_name}})
+{
+	print " | ".$center_public." | ".$center_history;
+}
+print " \n";
+print $break_line."\n";
+
+foreach my $table (sort {$a cmp $b} keys %{$anvil->data->{counts}})
+{
+	print " ".sprintf("%-${table_length}s", $table);
+	foreach my $host_name (sort {$a cmp $b} keys %{$anvil->data->{db_host_name}})
+	{
+		my $uuid         = $anvil->data->{db_host_name}{$host_name}{uuid};
+		my $public_rows  = $anvil->data->{counts}{$table}{$uuid}{public_comma};
+		my $history_rows = $anvil->data->{counts}{$table}{$uuid}{history_comma};
+		#print " | ".$public_rows." | ".$history_rows;
+		print " | ".sprintf("%${count_length}s", $public_rows)." | ".sprintf("%${count_length}s", $history_rows);
+	}
+	print " \n";
+}
+print $break_line."\n";
+
+$anvil->nice_exit({exit_code => 0});


### PR DESCRIPTION
* Created Database->_age_out_data() to delete records from the database that are old enough to no longer be useful. This is designed to significantly reduce the size of the database, allowing a better focus on performance.
* Changed Database->connect() to default to NOT check for resync, reworking the old 'no_resync' to 'check_for_resync', so that resync checks happen on demard, instead of by default.
* Updated get_tables_from_schema() to now allow 'schema_file' to be set to 'all', which then loads the schema files of all scan agents as well as the core anvil schema file. Fixed a bug where commented out tables were being counted.
* Re-enabled triggering resyncs on 'last_updated' differences.
* Fixed a bug in scan-ipmitool where the history_id column in history.scan_ipmitool_value was incorrect.
* Created a new tool called striker-show-db-counts that shows the number of records in all public and history schema tables for all databases.
* Updated anvil-update-states to detect when a libvirtd NAT'ed bridge exists and to delete it when found.

Signed-off-by: Digimer <digimer@alteeve.ca>