### PR TITLE
The theme of this commit is database cleanup and fixes.

### DIFF
--- a/Anvil/Tools/Job.pm
+++ b/Anvil/Tools/Job.pm
@@ -616,7 +616,7 @@ sub update_progress
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { message => $message, picked_up_by => $picked_up_by }});
 	if ($message eq "clear")
 	{
-		$picked_up_by = 0;
+		$picked_up_by = $$;
 		$clear_status = 1;
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 			picked_up_by => $picked_up_by,

--- a/Anvil/Tools/System.pm
+++ b/Anvil/Tools/System.pm
@@ -4933,7 +4933,7 @@ sub update_hosts
 					# Matches, we don't need to deal with this name.
 					delete $anvil->data->{hosts}{needed}{$name};
 				}
-				else
+				elsif ($ip_address ne "127.0.0.1")
 				{
 					# The IP has changed. Skip this name (which removes it from the list).
 					$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0481", variables => { 

--- a/anvil.conf
+++ b/anvil.conf
@@ -76,9 +76,9 @@ feature::scancore::disable::preventative-live-migration		=	0
 # NOTE: If the archive directory doesn't exist, Anvil! will create it 
 #       automatically the first time it is needed.
 sys::database::archive::compress				=	1
-sys::database::archive::trigger					=	50000
-sys::database::archive::count					=	25000
-sys::database::archive::division				=	30000
+sys::database::archive::trigger					=	100000
+sys::database::archive::count					=	50000
+sys::database::archive::division				=	75000
 sys::database::archive::directory				=	/usr/local/anvil/archives/
 
 # This puts a limit on how many queries (writes, generally) to make in a single batch transaction. This is 

--- a/share/words.xml
+++ b/share/words.xml
@@ -1787,6 +1787,9 @@ The file: [#!variable!file!#] needs to be updated. The difference is:
 		<key name="log_0619">The host: [#!variable!host_name!#] has shut down for thermal reasons: [#!variable!count!#] times. To prevent a frequent boot / thermal excursion / shutdown loop, we will wait: [#!variable!wait_for!#] before marking it's temperature as being OK again.</key>
 		<key name="log_0620">This host has been running for: [#!variable!uptime!#]. The cluster will not be started (uptime must be less than 10 minutes for 'anvil-safe-start' to be called automatically).</key>
 		<key name="log_0621">- The Scan agent: [#!variable!agent_name!#] ran a bit long, exiting after: [#!variable!runtime!#] seconds with the return code: [#!variable!return_code!#].</key>
+		<key name="log_0622">Aging out one or more records that are more than: [#!variable!age!#] hours old from the table: [#!variable!table!#] on the database host: [#!variable!database!#].</key>
+		<key name="log_0623">Starting the process of aging out old data. This can take about a minute, please be patient.</key>
+		<key name="log_0624">Aging out old data completed after: [#!variable!runtime!#] seconds.</key>
 		
 		<!-- Messages for users (less technical than log entries), though sometimes used for logs, too. -->
 		<key name="message_0001">The host name: [#!variable!target!#] does not resolve to an IP address.</key>

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -462,6 +462,9 @@ sub handle_periodic_tasks
 		###       recently enough.
 		if ($type eq "striker")
 		{
+			# Age out old data. This takes up to a minute. 
+			$anvil->Database->_age_out_data();
+			
 			# Record a job, don't call it directly. It takes too long to run.
 			my ($job_uuid) = $anvil->Database->insert_or_update_jobs({
 				file            => $THIS_FILE, 

--- a/tools/striker-get-peer-data
+++ b/tools/striker-get-peer-data
@@ -315,7 +315,7 @@ sub get_password
 	}
 	
 	# We'll pick up the peer's password from the database.
-	$anvil->Database->connect();
+	$anvil->Database->connect({check_for_resync => 1});
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 3, secure => 0, key => "log_0132"});
 	if (not $anvil->data->{sys}{database}{connections})
 	{

--- a/tools/striker-initialize-host
+++ b/tools/striker-initialize-host
@@ -43,7 +43,7 @@ $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list
 }});
 
 # Connect to the database(s).
-$anvil->Database->connect;
+$anvil->Database->connect({check_for_resync => 1});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0132"});
 if (not $anvil->data->{sys}{database}{connections})
 {

--- a/tools/striker-manage-install-target
+++ b/tools/striker-manage-install-target
@@ -123,7 +123,7 @@ if ($anvil->data->{switches}{status})
 }
 
 # Connect to the database(s).
-$anvil->Database->connect;
+$anvil->Database->connect({check_for_resync => 1});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 3, secure => 0, key => "log_0132"});
 if (not $anvil->data->{sys}{database}{connections})
 {

--- a/tools/striker-manage-peers
+++ b/tools/striker-manage-peers
@@ -63,7 +63,7 @@ if (($< != 0) && ($> != 0))
 }
 
 # We'll try to connect in case we're adding additional peers.
-$anvil->Database->connect();
+$anvil->Database->connect({check_for_resync => 1});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
 
 # Am I adding, editing or deleting?
@@ -543,6 +543,7 @@ sub process_entry
 			# Connect, and configure, if needed.
 			$anvil->Database->connect({
 				debug               => 3,
+				check_for_resync    => 1,
 				check_if_configured => $host_uuid eq $anvil->Get->host_uuid ? 1 : 0,
 			});
 			
@@ -623,7 +624,7 @@ sub process_entry
 				
 				sleep 1;
 				
-				$anvil->Database->connect({db_uuid => $host_uuid});
+				$anvil->Database->connect({check_for_resync => 1, db_uuid => $host_uuid});
 				$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
 			}
 		}

--- a/tools/striker-purge-target
+++ b/tools/striker-purge-target
@@ -20,7 +20,7 @@ if (($running_directory =~ /^\./) && ($ENV{PWD}))
 my $anvil = Anvil::Tools->new();
 
 
-$anvil->Database->connect({debug => 3});
+$anvil->Database->connect({check_for_resync => 1});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
 if (not $anvil->data->{sys}{database}{connections})
 {

--- a/tools/striker-scan-network
+++ b/tools/striker-scan-network
@@ -40,7 +40,7 @@ if (($< != 0) && ($> != 0))
 	$anvil->nice_exit({exit_code => 5});
 }
 
-$anvil->Database->connect;
+$anvil->Database->connect({check_for_resync => 1});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
 if (not $anvil->data->{sys}{database}{connections})
 {


### PR DESCRIPTION
* Updated Database->_age_out_data() to check for certain scan agent tables and, for those found, purge out old records. This should go a long way to keeping the database data responsive.
* Fixed a bug in Jobs->update_progress() where the 'job_picked_up_by' column was being set to '0' instead of '$$' when clearing the job.
* Fixed a bug in System->update_hosts() where '127.0.0.1' would be used in hosts for the actual host name.
* Updated the default trigger, count and division values in anvil.conf to 100,000, 50,000 and 75,000 respectively. In combination with the aging of data, this should go a long way to minimizing database sizes and overheads.
* Updated anvil-daemon to call $anvil->Database->_age_out_data(); in it's daily tasks.
* Updated various striker-X tools to specifically request a DB resync on Database->connect calls.

Signed-off-by: Digimer <digimer@alteeve.ca>