### PR TITLE
* Biggest change in this commit; scan-apc-pdu and scan-apc-ups now on…

### DIFF
--- a/Anvil/Tools.pm
+++ b/Anvil/Tools.pm
@@ -842,7 +842,7 @@ sub _set_defaults
 		database			=>	{
 			# This is the number of hours, after which, transient data (like temperature and 
 			# power data) is considered "old" and gets deleted from the database.
-			age_out				=>	48,
+			age_out				=>	24,
 		},
 	};
 	$anvil->data->{sys} = {

--- a/Anvil/Tools/ScanCore.pm
+++ b/Anvil/Tools/ScanCore.pm
@@ -289,7 +289,7 @@ sub call_scan_agents
 		my $runtime    = (time - $start_time);
 		my $log_level  = $debug;
 		my $string_key = "log_0557";
-		if ($runtime > 10)
+		if ($runtime > 15)
 		{
 			$log_level  = 1;
 			$string_key = "log_0621";
@@ -2154,7 +2154,7 @@ LIMIT 1;";
 		}
 		
 		# Check this target's power state.
-		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0561", variables => { host_name => $host_name }});
+		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0561", variables => { host_name => $host_name }});
 		
 		# Do we share a network with this system?
 		$anvil->Network->load_ips({
@@ -2206,7 +2206,7 @@ LIMIT 1;";
 				if ($access)
 				{
 					# It's up.
-					$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0562", variables => { host_name => $host_name }});
+					$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0562", variables => { host_name => $host_name }});
 					
 					$check_power = 0;
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 

--- a/anvil.conf
+++ b/anvil.conf
@@ -76,9 +76,9 @@ feature::scancore::disable::preventative-live-migration		=	0
 # NOTE: If the archive directory doesn't exist, Anvil! will create it 
 #       automatically the first time it is needed.
 sys::database::archive::compress				=	1
-sys::database::archive::trigger					=	100000
-sys::database::archive::count					=	50000
-sys::database::archive::division				=	75000
+sys::database::archive::trigger					=	500000
+sys::database::archive::count					=	100000
+sys::database::archive::division				=	125000
 sys::database::archive::directory				=	/usr/local/anvil/archives/
 
 # This puts a limit on how many queries (writes, generally) to make in a single batch transaction. This is 

--- a/scancore-agents/scan-apc-pdu/scan-apc-pdu
+++ b/scancore-agents/scan-apc-pdu/scan-apc-pdu
@@ -162,6 +162,14 @@ $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "
 # Read switches
 $anvil->Get->switches;
 
+# Too many connections cause the UPS to lag out, so we only run on Strikers.
+my $host_type = $anvil->Get->host_type();
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { host_type => $host_type }});
+if (($host_type ne "striker") && (not $anvil->data->{switches}{force}))
+{
+	$anvil->nice_exit({exit_code => 1});
+}
+
 # If we're disabled and '--force' wasn't used, exit.
 if (($anvil->data->{scancore}{'scan-apc-pdu'}{disable}) && (not $anvil->data->{switches}{force}))
 {

--- a/scancore-agents/scan-apc-ups/scan-apc-ups
+++ b/scancore-agents/scan-apc-ups/scan-apc-ups
@@ -189,6 +189,14 @@ $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "
 # Read switches
 $anvil->Get->switches;
 
+# Too many connections cause the UPS to lag out, so we only run on Strikers.
+my $host_type = $anvil->Get->host_type();
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { host_type => $host_type }});
+if (($host_type ne "striker") && (not $anvil->data->{switches}{force}))
+{
+	$anvil->nice_exit({exit_code => 1});
+}
+
 # If we're disabled and '--force' wasn't used, exit.
 if (($anvil->data->{scancore}{'scan-apc-ups'}{disable}) && (not $anvil->data->{switches}{force}))
 {
@@ -232,7 +240,11 @@ gather_ups_data($anvil);
 find_changes($anvil);
 
 # Update the database
-$anvil->Database->insert_or_update_updated({updated_by => $THIS_FILE});
+my $updated_uuid = $anvil->Database->insert_or_update_updated({
+	debug      => 2, 
+	updated_by => $THIS_FILE,
+});
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { updated_uuid => $updated_uuid }});
 
 # Clean up and go away.
 $anvil->nice_exit({exit_code => 0});

--- a/scancore-agents/scan-storcli/scan-storcli
+++ b/scancore-agents/scan-storcli/scan-storcli
@@ -6093,7 +6093,7 @@ AND
 									$message_key = "scan_storcli_warning_0006";
 									$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { message_key => $message_key }});
 								}
-								elsif ($old_variable_value > $new_variable_value)
+								elsif ($new_variable_value > $old_variable_value)
 								{
 									# Rising
 									my $jumped = ($new_variable_value - $old_variable_value);

--- a/share/words.xml
+++ b/share/words.xml
@@ -1596,7 +1596,7 @@ Failed to promote the DRBD resource: [#!variable!resource!#] primary. Expected a
 		<key name="log_0448">Ready to parse: [#!variable!file!#].</key>
 		<key name="log_0449">Parsed: [#!variable!records!#], adding/updating them to the database now.</key>
 		<key name="log_0450">Skipping the network scan. The next scheduled scan will be done in: [#!variable!next_scan!#]. Override with '--force'.</key>
-		<key name="log_0451">Checking to see if any data needs to be archived before starting the resync.</key>
+		<key name="log_0451">Checking to see if any data needs to be archived.</key>
 		<key name="log_0452">Skipping archiving, not a Striker dashboard.</key>
 		<key name="log_0453">Archiving: [#!variable!records!#] over: [#!variable!loops!#] segments from the table: [#!variable!table!#] from the database on: [#!variable!host!#]. This might take a bit, please be patient.</key>
 		<key name="log_0454">Writing: [#!variable!records!#] to the file: [#!variable!file!#].</key>

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -172,7 +172,7 @@ $anvil->data->{timing}{daily_checks}         = 86400;
 $anvil->data->{timing}{repo_update_interval} = 86400;
 $anvil->data->{timing}{next_minute_check}    = $now_time - 1;
 $anvil->data->{timing}{next_daily_check}     = ($now_time + $delay) - 1;
-$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 	"s1:timing::minute_checks"        => $anvil->data->{timing}{minute_checks}, 
 	"s2:timing::daily_checks"         => $anvil->data->{timing}{daily_checks}, 
 	"s3:timing::repo_update_interval" => $anvil->data->{timing}{repo_update_interval}, 
@@ -337,7 +337,7 @@ sub set_delay
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { type => $type }});
 	if ($type eq "striker")
 	{
-		foreach my $uuid (sort {$a cmp $b} keys %{$anvil->data->{database}})
+		foreach my $uuid (keys %{$anvil->data->{database}})
 		{
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
 				"sys::host_uuid" => $anvil->data->{sys}{host_uuid}, 
@@ -464,6 +464,9 @@ sub handle_periodic_tasks
 		{
 			# Age out old data. This takes up to a minute. 
 			$anvil->Database->_age_out_data();
+			
+			# Archive old data
+			$anvil->Database->archive_database();
 			
 			# Record a job, don't call it directly. It takes too long to run.
 			my ($job_uuid) = $anvil->Database->insert_or_update_jobs({

--- a/tools/scancore
+++ b/tools/scancore
@@ -106,7 +106,7 @@ while(1)
 	prepare_for_run($anvil);
 	
 	# Set our sleep time
-	my $run_interval = 30;
+	my $run_interval = 60;
 	if ((exists $anvil->data->{scancore}{timing}{run_interval}) && ($anvil->data->{scancore}{timing}{run_interval} =~ /^\d+$/))
 	{
 		$run_interval = $anvil->data->{scancore}{timing}{run_interval};


### PR DESCRIPTION
…ly run on Striker dashboards! This was because we found that if two machines ran their agents at the same time, the reponce time from SNMP read requests grew a lot. This meant it was likely a third, fourth and so on machne would also then have their scan agent runs while the existing runs were still trying to process, causing the SNMP reads to get slower still until timeouts popped.

* Bumped scancore's scan delay from 30 seconds to 60.
* Shorted the age-out time to 24 hours and again boosted the archive thresholds. As we get a feel for the amount of data collected on multi-Anvil! systems over time, we may continue to tune this.l
* Moved Database->archive_database() to be called daily by anvil-daemon, instead of during '->connect' calls.
* Added locking to Database->_age_out_data to avoid resyncs mid-purge. Also moved the power, temperature and ip_address columns into the same 'to_clean' hash as it was duplicate logic.

Signed-off-by: Digimer <digimer@alteeve.ca>