### PR TITLE
* This contains a fairly major change to how time stamps are handled.…

### DIFF
--- a/Anvil/Tools/Account.pm
+++ b/Anvil/Tools/Account.pm
@@ -437,7 +437,7 @@ UPDATE
     sessions 
 SET 
     session_salt      = '', 
-    modified_date     = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date     = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     session_user_uuid = ".$anvil->Database->quote($user_uuid)." ";
 	if ($host_uuid ne "all")

--- a/Anvil/Tools/Alert.pm
+++ b/Anvil/Tools/Alert.pm
@@ -212,7 +212,7 @@ INSERT INTO
     ".$anvil->Database->quote($anvil->Get->host_uuid).", 
     ".$anvil->Database->quote($set_by).", 
     ".$anvil->Database->quote($record_locator).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );
 ";
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
@@ -594,7 +594,7 @@ INSERT INTO
     ".$anvil->Database->quote($message).", 
     ".$anvil->Database->quote($sort_position).", 
     ".$anvil->Database->quote($show_header).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );
 ";
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { query => $query }});

--- a/Anvil/Tools/Server.pm
+++ b/Anvil/Tools/Server.pm
@@ -239,7 +239,7 @@ SET
     server_boot_time = ".$anvil->Database->quote($boot_time).",  ";
 							}
 							$query .= "
-    modified_date    = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date    = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     server_uuid      = ".$anvil->Database->quote($server_uuid)."
 ;";
@@ -1011,7 +1011,7 @@ UPDATE
     servers 
 SET 
     server_state  = 'migrating',
-    modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     server_uuid   = ".$anvil->Database->quote($server_uuid)."
 ;";
@@ -1070,7 +1070,6 @@ WHERE
 	if ($anvil->data->{sys}{database}{connections})
 	{
 		$anvil->Database->get_servers({debug => 2});
-		$anvil->Database->refresh_timestamp({debug => $debug});
 	}
 	if ($return_code)
 	{
@@ -1090,7 +1089,7 @@ UPDATE
     servers 
 SET 
     server_state  = ".$anvil->Database->quote($old_server_state).", 
-    modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     server_uuid   = ".$anvil->Database->quote($server_uuid)."
 ;";
@@ -1134,7 +1133,7 @@ UPDATE
 SET 
     server_state     = ".$anvil->Database->quote($old_server_state).", 
     server_host_uuid = ".$anvil->Database->quote($server_host_uuid).", 
-    modified_date    = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date    = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     server_uuid      = ".$anvil->Database->quote($server_uuid)."
 ;";
@@ -1950,7 +1949,7 @@ UPDATE
     servers 
 SET 
     server_state  = 'in shutdown',
-    modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     server_uuid   = ".$anvil->Database->quote($server_uuid)."
 ;";
@@ -2022,7 +2021,6 @@ WHERE
 					if ($old_state ne "shut off")
 					{
 						# Update it.
-						$anvil->Database->refresh_timestamp({debug => $debug});
 						my $query = "
 UPDATE 
     servers 
@@ -2030,7 +2028,7 @@ SET
     server_state     = 'shut off', 
     server_boot_time = 0, 
     server_host_uuid = NULL, 
-    modified_date    = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date    = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     server_uuid      = ".$anvil->Database->quote($server_uuid)."
 ;";

--- a/cgi-bin/striker
+++ b/cgi-bin/striker
@@ -1498,7 +1498,7 @@ UPDATE
     files 
 SET 
     file_type     = 'DELETED', 
-    modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     file_uuid     = ".$anvil->Database->quote($file_uuid)."
 ;";
@@ -1542,7 +1542,7 @@ UPDATE
     files 
 SET 
     file_name     = ".$anvil->Database->quote($new_file_name).", 
-    modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     file_uuid     = ".$anvil->Database->quote($file_uuid)."
 ;";
@@ -1579,7 +1579,7 @@ UPDATE
     files 
 SET 
     file_type     = ".$anvil->Database->quote($anvil->data->{cgi}{new_file_type}{value}).", 
-    modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     file_uuid     = ".$anvil->Database->quote($file_uuid)."
 ;";
@@ -1660,7 +1660,7 @@ UPDATE
     file_locations 
 SET 
     file_location_active = ".$anvil->Database->quote($new_active).", 
-    modified_date        = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date        = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     file_location_uuid   = ".$anvil->Database->quote($file_location_uuid)."
 ;";

--- a/scancore-agents/scan-apc-pdu/scan-apc-pdu
+++ b/scancore-agents/scan-apc-pdu/scan-apc-pdu
@@ -852,7 +852,7 @@ SET
     scan_apc_pdu_link_speed       = ".$anvil->Database->quote($new_scan_apc_pdu_link_speed).", 
     scan_apc_pdu_phase_count      = ".$anvil->Database->quote($new_scan_apc_pdu_phase_count).", 
     scan_apc_pdu_outlet_count     = ".$anvil->Database->quote($new_scan_apc_pdu_outlet_count).", 
-    modified_date                 = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                 = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_pdu_uuid             = ".$anvil->Database->quote($scan_apc_pdu_uuid)." 
 ;";
@@ -1128,7 +1128,7 @@ SET
     scan_apc_pdu_phase_number            = ".$anvil->Database->quote($scan_apc_pdu_phase_number).", 
     scan_apc_pdu_phase_current_amperage  = ".$anvil->Database->quote($new_scan_apc_pdu_phase_current_amperage).", 
     scan_apc_pdu_phase_max_amperage      = ".$anvil->Database->quote($new_scan_apc_pdu_phase_max_amperage).", 
-    modified_date                        = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                        = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_pdu_phase_uuid              = ".$anvil->Database->quote($scan_apc_pdu_phase_uuid)." 
 ;";
@@ -1158,7 +1158,7 @@ UPDATE
     scan_apc_pdu_phases 
 SET 
     scan_apc_pdu_phase_deleted = 'DELETED', 
-    modified_date              = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date              = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_pdu_phase_uuid    = ".$anvil->Database->quote($scan_apc_pdu_phase_uuid)." 
 ;";
@@ -1305,7 +1305,7 @@ SET
     scan_apc_pdu_outlet_name              = ".$anvil->Database->quote($new_scan_apc_pdu_outlet_name).", 
     scan_apc_pdu_outlet_on_phase          = ".$anvil->Database->quote($new_scan_apc_pdu_outlet_on_phase).", 
     scan_apc_pdu_outlet_state             = ".$anvil->Database->quote($new_scan_apc_pdu_outlet_state).", 
-    modified_date                         = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                         = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_pdu_outlet_uuid              = ".$anvil->Database->quote($scan_apc_pdu_outlet_uuid)." 
 ;";
@@ -1369,7 +1369,7 @@ UPDATE
     scan_apc_pdu_outlets 
 SET 
     scan_apc_pdu_outlet_name = 'DELETED', 
-    modified_date            = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date            = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_pdu_outlet_uuid = ".$anvil->Database->quote($scan_apc_pdu_outlet_uuid)." 
 ;";
@@ -1432,7 +1432,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_apc_pdu_link_speed).", 
     ".$anvil->Database->quote($new_scan_apc_pdu_phase_count).", 
     ".$anvil->Database->quote($new_scan_apc_pdu_outlet_count).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 			push @{$anvil->data->{sys}{queries}}, $query;
@@ -1526,7 +1526,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_apc_pdu_phase_number).", 
     ".$anvil->Database->quote($new_scan_apc_pdu_phase_current_amperage).", 
     ".$anvil->Database->quote($new_scan_apc_pdu_phase_max_amperage).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 				push @{$anvil->data->{sys}{queries}}, $query;
@@ -1614,7 +1614,7 @@ UPDATE
     scan_apc_pdus 
 SET 
     scan_apc_pdu_model_number = 'DELETED', 
-    modified_date             = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date             = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_pdu_uuid         = ".$anvil->Database->quote($scan_apc_pdu_uuid)." 
 ;";
@@ -1795,7 +1795,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_apc_pdu_outlet_name).", 
     ".$anvil->Database->quote($scan_apc_pdu_outlet_on_phase).", 
     ".$anvil->Database->quote($scan_apc_pdu_outlet_state).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 	push @{$anvil->data->{sys}{queries}}, $query;
@@ -1814,7 +1814,7 @@ UPDATE
 SET
     scan_apc_pdu_variable_name  = ".$anvil->Database->quote($variable).", 
     scan_apc_pdu_variable_value = ".$anvil->Database->quote($value).", 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_pdu_variable_uuid  = ".$anvil->Database->quote($scan_apc_pdu_variable_uuid)." 
 ;";
@@ -1846,7 +1846,7 @@ INSERT INTO
     FALSE, 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 	push @{$anvil->data->{sys}{queries}}, $query;

--- a/scancore-agents/scan-apc-ups/scan-apc-ups
+++ b/scancore-agents/scan-apc-ups/scan-apc-ups
@@ -376,7 +376,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_apc_ups_nmc_firmware_version).", 
     ".$anvil->Database->quote($scan_apc_ups_nmc_serial_number).", 
     ".$anvil->Database->quote($scan_apc_ups_nmc_mac_address).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 			$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});
@@ -852,7 +852,7 @@ SET
     scan_apc_ups_nmc_firmware_version  = ".$anvil->Database->quote($scan_apc_ups_nmc_firmware_version).", 
     scan_apc_ups_nmc_serial_number     = ".$anvil->Database->quote($scan_apc_ups_nmc_serial_number).", 
     scan_apc_ups_nmc_mac_address       = ".$anvil->Database->quote($scan_apc_ups_nmc_mac_address).", 
-    modified_date                      = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                      = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_ups_uuid                  = ".$anvil->Database->quote($scan_apc_ups_uuid)." 
 ;";
@@ -1091,7 +1091,7 @@ SET
     scan_apc_ups_input_voltage                  = ".$anvil->Database->quote($scan_apc_ups_input_voltage).", 
     scan_apc_ups_input_1m_maximum_input_voltage = ".$anvil->Database->quote($scan_apc_ups_input_1m_maximum_input_voltage).", 
     scan_apc_ups_input_1m_minimum_input_voltage = ".$anvil->Database->quote($scan_apc_ups_input_1m_minimum_input_voltage).", 
-    modified_date                               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_ups_input_uuid                     = ".$anvil->Database->quote($scan_apc_ups_input_uuid)."
 ;";
@@ -1328,7 +1328,7 @@ SET
     scan_apc_ups_output_frequency         = ".$anvil->Database->quote($scan_apc_ups_output_frequency).", 
     scan_apc_ups_output_voltage           = ".$anvil->Database->quote($scan_apc_ups_output_voltage).", 
     scan_apc_ups_output_total_output      = ".$anvil->Database->quote($scan_apc_ups_output_total_output).", 
-    modified_date                         = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                         = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_ups_output_uuid              = ".$anvil->Database->quote($scan_apc_ups_output_uuid)."
 ";
@@ -1779,7 +1779,7 @@ SET
     scan_apc_ups_battery_temperature           = ".$anvil->Database->quote($scan_apc_ups_battery_temperature).",
     scan_apc_ups_battery_alarm_temperature     = ".$anvil->Database->quote($scan_apc_ups_battery_alarm_temperature).",
     scan_apc_ups_battery_voltage               = ".$anvil->Database->quote($scan_apc_ups_battery_voltage).",
-    modified_date                              = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                              = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_apc_ups_battery_uuid                  = ".$anvil->Database->quote($scan_apc_ups_battery_uuid)."
 ";
@@ -3145,7 +3145,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_apc_ups_battery_temperature).",  
     ".$anvil->Database->quote($scan_apc_ups_battery_alarm_temperature).",  
     ".$anvil->Database->quote($scan_apc_ups_battery_voltage).",  
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 	$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});
@@ -3213,7 +3213,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_apc_ups_input_voltage).",  
     ".$anvil->Database->quote($scan_apc_ups_input_1m_maximum_input_voltage).",  
     ".$anvil->Database->quote($scan_apc_ups_input_1m_minimum_input_voltage).",  
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 	$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});
@@ -3281,7 +3281,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_apc_ups_output_frequency).",  
     ".$anvil->Database->quote($scan_apc_ups_output_voltage).",  
     ".$anvil->Database->quote($scan_apc_ups_output_total_output).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 	$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});

--- a/scancore-agents/scan-cluster/scan-cluster
+++ b/scancore-agents/scan-cluster/scan-cluster
@@ -177,7 +177,7 @@ UPDATE
     scan_cluster 
 SET 
     scan_cluster_name = ".$anvil->Database->quote($cluster_name).", 
-    modified_date     = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date     = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_cluster_uuid = ".$anvil->Database->quote($scan_cluster_uuid)."
 ;";
@@ -198,7 +198,7 @@ UPDATE
     scan_cluster 
 SET 
     scan_cluster_cib  = ".$anvil->Database->quote($cluster_cib).", 
-    modified_date     = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date     = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_cluster_uuid = ".$anvil->Database->quote($scan_cluster_uuid)."
 ;";
@@ -234,7 +234,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_cluster_anvil_uuid).",
     ".$anvil->Database->quote($cluster_name).", 
     ".$anvil->Database->quote($cluster_cib).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 		$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});
@@ -375,7 +375,7 @@ SET
     scan_cluster_node_crmd_member      = ".$anvil->Database->quote($scan_cluster_node_crmd_member).", 
     scan_cluster_node_cluster_member   = ".$anvil->Database->quote($scan_cluster_node_cluster_member).", 
     scan_cluster_node_maintenance_mode = ".$anvil->Database->quote($scan_cluster_node_maintenance_mode).", 
-    modified_date                      = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                      = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE
     scan_cluster_node_uuid             = ".$anvil->Database->quote($scan_cluster_node_uuid)."
 ;";
@@ -411,7 +411,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_cluster_node_crmd_member).", 
     ".$anvil->Database->quote($scan_cluster_node_cluster_member).", 
     ".$anvil->Database->quote($scan_cluster_node_maintenance_mode).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 			$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});
@@ -648,7 +648,7 @@ SET
     scan_cluster_node_in_ccm         = '0', 
     scan_cluster_node_crmd_member    = '0', 
     scan_cluster_node_cluster_member = '0',
-    modified_date                    = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                    = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_cluster_node_uuid           = ".$anvil->Database->quote($scan_cluster_node_uuid)."
 ;";

--- a/scancore-agents/scan-drbd/scan-drbd
+++ b/scancore-agents/scan-drbd/scan-drbd
@@ -246,7 +246,7 @@ SET
     scan_drbd_flush_md         = ".$anvil->Database->quote($new_scan_drbd_flush_md).", 
     scan_drbd_timeout          = ".$anvil->Database->quote($new_scan_drbd_timeout).", 
     scan_drbd_total_sync_speed = ".$anvil->Database->quote($new_scan_drbd_total_sync_speed).", 
-    modified_date              = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date              = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_drbd_uuid             = ".$anvil->Database->quote($scan_drbd_uuid)."
 ;
@@ -306,7 +306,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_drbd_flush_md).", 
     ".$anvil->Database->quote($new_scan_drbd_timeout).", 
     ".$anvil->Database->quote($new_scan_drbd_total_sync_speed).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 		# Now record the query in the array
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -404,7 +404,7 @@ SET
     scan_drbd_resource_name = ".$anvil->Database->quote($scan_drbd_resource_name).", 
     scan_drbd_resource_up   = ".$anvil->Database->quote($new_scan_drbd_resource_up).", 
     scan_drbd_resource_xml  = ".$anvil->Database->quote($new_scan_drbd_resource_xml).", 
-    modified_date           = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date           = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_drbd_resource_uuid = ".$anvil->Database->quote($scan_drbd_resource_uuid)."
 ;";
@@ -453,7 +453,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_drbd_resource_name).", 
     ".$anvil->Database->quote($new_scan_drbd_resource_up).", 
     ".$anvil->Database->quote($new_scan_drbd_resource_xml).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 		# Now record the query in the array
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -726,7 +726,7 @@ SET
     scan_drbd_peer_tcp_port               = ".$anvil->Database->quote($new_scan_drbd_peer_tcp_port).", 
     scan_drbd_peer_protocol               = ".$anvil->Database->quote($new_scan_drbd_peer_protocol).", 
     scan_drbd_peer_fencing                = ".$anvil->Database->quote($new_scan_drbd_peer_fencing).", 
-    modified_date                         = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                         = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE
     scan_drbd_peer_uuid                   = ".$anvil->Database->quote($scan_drbd_peer_uuid)." 
 ;";
@@ -809,7 +809,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_drbd_peer_tcp_port).", 
     ".$anvil->Database->quote($new_scan_drbd_peer_protocol).", 
     ".$anvil->Database->quote($new_scan_drbd_peer_fencing).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 				# Now record the query immediately
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -916,7 +916,7 @@ SET
     scan_drbd_volume_device_path  = ".$anvil->Database->quote($new_scan_drbd_volume_device_path).", 
     scan_drbd_volume_device_minor = ".$anvil->Database->quote($new_scan_drbd_volume_device_minor).", 
     scan_drbd_volume_size         = ".$anvil->Database->quote($new_scan_drbd_volume_size).", 
-    modified_date                 = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date                 = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_drbd_volume_uuid         = ".$anvil->Database->quote($scan_drbd_volume_uuid)."
 ;";
@@ -963,7 +963,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_drbd_volume_device_path).", 
     ".$anvil->Database->quote($new_scan_drbd_volume_device_minor).", 
     ".$anvil->Database->quote($new_scan_drbd_volume_size).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			# Now record the query in the array
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1029,7 +1029,7 @@ UPDATE
     scan_drbd_resources
 SET 
     scan_drbd_resource_xml  = 'DELETED', 
-    modified_date           = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date           = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_drbd_resource_uuid = ".$anvil->Database->quote($scan_drbd_resource_uuid)."
 ;
@@ -1065,7 +1065,7 @@ UPDATE
     scan_drbd_volumes
 SET 
     scan_drbd_volume_device_path = 'DELETED', 
-    modified_date                = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date                = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_drbd_volume_uuid        = ".$anvil->Database->quote($scan_drbd_volume_uuid)."
 ;";
@@ -1103,7 +1103,7 @@ UPDATE
     scan_drbd_peers
 SET 
     scan_drbd_peer_connection_state = 'DELETED', 
-    modified_date                   = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date                   = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_drbd_peer_uuid             = ".$anvil->Database->quote($scan_drbd_peer_uuid)."
 ;";

--- a/scancore-agents/scan-filesystems/scan-filesystems
+++ b/scancore-agents/scan-filesystems/scan-filesystems
@@ -379,7 +379,7 @@ SET
     scan_filesystem_description   = ".$anvil->Database->quote($new_description).", 
     scan_filesystem_size          = ".$anvil->Database->quote($new_size).", 
     scan_filesystem_used          = ".$anvil->Database->quote($new_used).", 
-    modified_date                 = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date                 = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_filesystem_uuid          = ".$anvil->Database->quote($filesystem_uuid)."
 ;";
@@ -429,7 +429,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_description).", 
     ".$anvil->Database->quote($new_size).", 
     ".$anvil->Database->quote($new_used).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 			$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});
@@ -580,7 +580,7 @@ UPDATE
     scan_filesystems 
 SET 
     scan_filesystem_mount_point = 'REMOVED', 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_filesystem_uuid        = ".$anvil->Database->quote($filesystem_uuid)."
 ;";

--- a/scancore-agents/scan-hardware/scan-hardware
+++ b/scancore-agents/scan-hardware/scan-hardware
@@ -1011,7 +1011,7 @@ SET
     scan_hardware_led_id       = ".$anvil->Database->quote($new_scan_hardware_led_id).", 
     scan_hardware_led_css      = ".$anvil->Database->quote($new_scan_hardware_led_css).", 
     scan_hardware_led_error    = ".$anvil->Database->quote($new_scan_hardware_led_error).", 
-    modified_date              = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date              = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hardware_uuid         = ".$anvil->Database->quote($scan_hardware_uuid)."
 ;";
@@ -1077,7 +1077,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_hardware_led_id).", 
     ".$anvil->Database->quote($new_scan_hardware_led_css).", 
     ".$anvil->Database->quote($new_scan_hardware_led_css).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 		# Now record the query in the array
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1172,7 +1172,7 @@ SET
     scan_hardware_ram_module_manufacturer  = ".$anvil->Database->quote($new_scan_hardware_ram_module_manufacturer).", 
     scan_hardware_ram_module_model         = ".$anvil->Database->quote($new_scan_hardware_ram_module_model).", 
     scan_hardware_ram_module_serial_number = ".$anvil->Database->quote($new_scan_hardware_ram_module_serial_number).", 
-    modified_date                          = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                          = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hardware_ram_module_uuid          = ".$anvil->Database->quote($scan_hardware_ram_module_uuid)." 
 ;";
@@ -1216,7 +1216,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_hardware_ram_module_manufacturer).", 
     ".$anvil->Database->quote($new_scan_hardware_ram_module_model).", 
     ".$anvil->Database->quote($new_scan_hardware_ram_module_serial_number).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			# Now record the query in the array
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1264,7 +1264,7 @@ UPDATE
     scan_hardware_ram_modules 
 SET
     scan_hardware_ram_module_manufacturer  = 'VANISHED', 
-    modified_date                     = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                     = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hardware_ram_module_uuid          = ".$anvil->Database->quote($scan_hardware_ram_module_uuid)." 
 ;";

--- a/scancore-agents/scan-hpacucli/scan-hpacucli
+++ b/scancore-agents/scan-hpacucli/scan-hpacucli
@@ -249,7 +249,7 @@ UPDATE
     scan_hpacucli_controllers
 SET 
     scan_hpacucli_controller_last_diagnostics = ".time.", 
-    modified_date                             = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                             = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_controller_host_uuid        = ".$anvil->Database->quote($anvil->Get->host_uuid)."
 ;";
@@ -691,7 +691,7 @@ SET
     scan_hpacucli_array_type            = ".$anvil->Database->quote($new_scan_hpacucli_array_type).", 
     scan_hpacucli_array_status          = ".$anvil->Database->quote($new_scan_hpacucli_array_status).", 
     scan_hpacucli_array_error_message   = ".$anvil->Database->quote($new_scan_hpacucli_array_error_message).", 
-    modified_date                       = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                       = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_array_uuid            = ".$anvil->Database->quote($scan_hpacucli_array_uuid)." 
 ;";
@@ -762,7 +762,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_hpacucli_array_type).", 
     ".$anvil->Database->quote($new_scan_hpacucli_array_status).", 
     ".$anvil->Database->quote($new_scan_hpacucli_array_error_message).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 				# Now record the query in the array
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1063,7 +1063,7 @@ SET
     scan_hpacucli_logical_drive_strip_size     = $quoted_scan_hpacucli_logical_drive_strip_size, 
     scan_hpacucli_logical_drive_stripe_size    = $quoted_scan_hpacucli_logical_drive_stripe_size, 
     scan_hpacucli_logical_drive_status         = ".$anvil->Database->quote($new_scan_hpacucli_logical_drive_status).", 
-    modified_date                              = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                              = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_logical_drive_uuid           = ".$anvil->Database->quote($scan_hpacucli_logical_drive_uuid)." 
 ;";
@@ -1158,7 +1158,7 @@ INSERT INTO
     $quoted_scan_hpacucli_logical_drive_strip_size, 
     $quoted_scan_hpacucli_logical_drive_stripe_size, 
     ".$anvil->Database->quote($new_scan_hpacucli_logical_drive_status).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					# Now record the query in the array
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1221,7 +1221,7 @@ UPDATE
     scan_hpacucli_variables 
 SET 
     scan_hpacucli_variable_value = ".$anvil->Database->quote($new_scan_hpacucli_variable_value).", 
-    modified_date                = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_variable_uuid  = ".$anvil->Database->quote($scan_hpacucli_variable_uuid)."
 ;";
@@ -1269,7 +1269,7 @@ INSERT INTO
     FALSE, 
     ".$anvil->Database->quote($scan_hpacucli_variable_name).", 
     ".$anvil->Database->quote($new_scan_hpacucli_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 						# Now record the query in the array
 						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1330,7 +1330,7 @@ UPDATE
     scan_hpacucli_arrays
 SET
     scan_hpacucli_array_status = 'VANISHED', 
-    modified_date              = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date              = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_array_uuid   = ".$anvil->Database->quote($scan_hpacucli_array_uuid)." 
 ;";
@@ -1375,7 +1375,7 @@ UPDATE
     scan_hpacucli_logical_drives
 SET
     scan_hpacucli_logical_drive_status = 'VANISHED', 
-    modified_date                      = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                      = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_logical_drive_uuid   = ".$anvil->Database->quote($scan_hpacucli_logical_drive_uuid)." 
 ;";
@@ -2015,7 +2015,7 @@ SET
     scan_hpacucli_physical_drive_port                = ".$anvil->Database->quote($port).", 
     scan_hpacucli_physical_drive_box                 = ".$anvil->Database->quote($box).", 
     scan_hpacucli_physical_drive_bay                 = ".$anvil->Database->quote($bay).", 
-    modified_date                                    = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                                    = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_physical_drive_uuid                = ".$anvil->Database->quote($scan_hpacucli_physical_drive_uuid)." 
 ;";
@@ -2320,7 +2320,7 @@ INSERT INTO
     ".$anvil->Database->quote($port).", 
     ".$anvil->Database->quote($box).", 
     ".$anvil->Database->quote($bay).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 		# Now record the query in the array
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -2379,7 +2379,7 @@ UPDATE
     scan_hpacucli_variables 
 SET 
     scan_hpacucli_variable_value = ".$anvil->Database->quote($new_scan_hpacucli_variable_value).", 
-    modified_date                = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_variable_uuid  = ".$anvil->Database->quote($scan_hpacucli_variable_uuid)."
 ;";
@@ -2431,7 +2431,7 @@ INSERT INTO
     FALSE, 
     ".$anvil->Database->quote($scan_hpacucli_variable_name).", 
     ".$anvil->Database->quote($new_scan_hpacucli_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			# Now record the query in the array
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -2477,7 +2477,7 @@ UPDATE
     scan_hpacucli_variables 
 SET 
     scan_hpacucli_variable_value = 'VANISHED', 
-    modified_date           = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date           = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_variable_uuid  = ".$anvil->Database->quote($old_scan_hpacucli_variable_uuid)."
 ;";
@@ -2549,7 +2549,7 @@ UPDATE
     scan_hpacucli_variables 
 SET 
     scan_hpacucli_variable_value = ".$anvil->Database->quote($new_scan_hpacucli_variable_value).", 
-    modified_date                = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_variable_uuid  = ".$anvil->Database->quote($scan_hpacucli_variable_uuid)."
 ;";
@@ -2601,7 +2601,7 @@ INSERT INTO
     FALSE, 
     ".$anvil->Database->quote($scan_hpacucli_variable_name).", 
     ".$anvil->Database->quote($new_scan_hpacucli_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					# Now record the query in the array
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -2649,7 +2649,7 @@ UPDATE
     scan_hpacucli_variables 
 SET 
     scan_hpacucli_variable_value = 'VANISHED', 
-    modified_date                = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_variable_uuid  = ".$anvil->Database->quote($old_scan_hpacucli_variable_uuid)."
 ;";
@@ -2881,7 +2881,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_hpacucli_controller_drive_write_cache).", 
     ".$anvil->Database->quote($new_scan_hpacucli_controller_firmware_version).", 
     ".$anvil->Database->quote($new_scan_hpacucli_controller_unsafe_writeback_cache).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			# Now record the query in the array
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -2983,7 +2983,7 @@ SET
     scan_hpacucli_controller_drive_write_cache      = ".$anvil->Database->quote($new_scan_hpacucli_controller_drive_write_cache).", 
     scan_hpacucli_controller_firmware_version       = ".$anvil->Database->quote($new_scan_hpacucli_controller_firmware_version).", 
     scan_hpacucli_controller_unsafe_writeback_cache = ".$anvil->Database->quote($new_scan_hpacucli_controller_unsafe_writeback_cache).", 
-    modified_date                                   = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                                   = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_controller_uuid                   = ".$anvil->Database->quote($scan_hpacucli_controller_uuid)." 
 ;";
@@ -3084,7 +3084,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_hpacucli_cache_module_status).", 
     ".$anvil->Database->quote($new_scan_hpacucli_cache_module_type).", 
     ".$anvil->Database->quote($new_scan_hpacucli_cache_module_size).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 				# Now record the query in the array
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -3188,7 +3188,7 @@ SET
     scan_hpacucli_cache_module_status          = ".$anvil->Database->quote($new_scan_hpacucli_cache_module_status).", 
     scan_hpacucli_cache_module_type            = ".$anvil->Database->quote($new_scan_hpacucli_cache_module_type).", 
     scan_hpacucli_cache_module_size            = ".$anvil->Database->quote($new_scan_hpacucli_cache_module_size).", 
-    modified_date                              = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                              = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_cache_module_uuid            = ".$anvil->Database->quote($scan_hpacucli_cache_module_uuid)." 
 ;";
@@ -3561,7 +3561,7 @@ UPDATE
     scan_hpacucli_variables 
 SET 
     scan_hpacucli_variable_value = ".$anvil->Database->quote($new_scan_hpacucli_variable_value).", 
-    modified_date                = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -3795,7 +3795,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($new_scan_hpacucli_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					# Now record the query in the array
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -3849,7 +3849,7 @@ UPDATE
     scan_hpacucli_controllers 
 SET 
     scan_hpacucli_controller_status = 'VANISHED', 
-    modified_date                   = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                   = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_controller_uuid   = ".$anvil->Database->quote($scan_hpacucli_controller_uuid)." 
 ;";
@@ -3899,7 +3899,7 @@ UPDATE
     scan_hpacucli_cache_modules 
 SET 
     scan_hpacucli_cache_module_status = 'VANISHED', 
-    modified_date                     = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                     = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_cache_module_uuid   = ".$anvil->Database->quote($scan_hpacucli_cache_module_uuid)." 
 ;";
@@ -3959,7 +3959,7 @@ UPDATE
     scan_hpacucli_variables 
 SET 
     scan_hpacucli_variable_value = 'VANISHED', 
-    modified_date                = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_hpacucli_variable_uuid  = ".$anvil->Database->quote($old_scan_hpacucli_variable_uuid)."
 ;";

--- a/scancore-agents/scan-ipmitool/scan-ipmitool
+++ b/scancore-agents/scan-ipmitool/scan-ipmitool
@@ -475,7 +475,7 @@ UPDATE
     scan_ipmitool_values 
 SET
     scan_ipmitool_value_sensor_value       = ".$anvil->Database->quote($new_scan_ipmitool_value_sensor_value).", 
-    modified_date                          = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date                          = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_ipmitool_value_scan_ipmitool_uuid = ".$anvil->Database->quote($scan_ipmitool_uuid)."
 ;
@@ -594,7 +594,7 @@ SET
     scan_ipmitool_sensor_high_warning  = ".$anvil->Database->quote($new_scan_ipmitool_sensor_high_warning).", 
     scan_ipmitool_sensor_low_critical  = ".$anvil->Database->quote($new_scan_ipmitool_sensor_low_critical).", 
     scan_ipmitool_sensor_low_warning   = ".$anvil->Database->quote($new_scan_ipmitool_sensor_low_warning).", 
-    modified_date                      = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date                      = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     scan_ipmitool_sensor_host          = ".$anvil->Database->quote($host_name)."
 AND 
@@ -713,7 +713,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_ipmitool_sensor_high_warning).",  
     ".$anvil->Database->quote($new_scan_ipmitool_sensor_low_critical).",  
     ".$anvil->Database->quote($new_scan_ipmitool_sensor_low_warning).",  
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					$query =~ s/'NULL'/NULL/g;
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -735,7 +735,7 @@ INSERT INTO
     ".$anvil->Database->quote($anvil->Get->host_uuid).", 
     ".$anvil->Database->quote($scan_ipmitool_uuid).", 
     ".$anvil->Database->quote($new_scan_ipmitool_value_sensor_value).",  
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					$query =~ s/'NULL'/NULL/g;
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -858,7 +858,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_scan_ipmitool_sensor_high_warning).",  
     ".$anvil->Database->quote($new_scan_ipmitool_sensor_low_critical).",  
     ".$anvil->Database->quote($new_scan_ipmitool_sensor_low_warning).",  
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 				$query =~ s/'NULL'/NULL/g;
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -880,7 +880,7 @@ INSERT INTO
     ".$anvil->Database->quote($anvil->Get->host_uuid).",
     ".$anvil->Database->quote($scan_ipmitool_uuid).",
     ".$anvil->Database->quote($new_scan_ipmitool_value_sensor_value).",  
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 				$query =~ s/'NULL'/NULL/g;
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});

--- a/scancore-agents/scan-lvm/scan-lvm
+++ b/scancore-agents/scan-lvm/scan-lvm
@@ -281,7 +281,7 @@ SET
     scan_lvm_lv_size       = ".$anvil->Database->quote($scan_lvm_lv_size).", 
     scan_lvm_lv_path       = ".$anvil->Database->quote($scan_lvm_lv_path).", 
     scan_lvm_lv_on_pvs     = ".$anvil->Database->quote($scan_lvm_lv_on_pvs).", 
-    modified_date          = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date          = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_lvm_lv_uuid       = ".$anvil->Database->quote($scan_lvm_lv_uuid)." 
 ;";
@@ -333,7 +333,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_lvm_lv_size).", 
     ".$anvil->Database->quote($scan_lvm_lv_path).", 
     ".$anvil->Database->quote($scan_lvm_lv_on_pvs).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 			$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});
@@ -366,7 +366,7 @@ UPDATE
     scan_lvm_lvs
 SET 
     scan_lvm_lv_name = 'DELETED',
-    modified_date    = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date    = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_lvm_lv_uuid = ".$anvil->Database->quote($scan_lvm_lv_uuid)."
 ;";
@@ -538,7 +538,7 @@ SET
     scan_lvm_vg_extent_size = ".$anvil->Database->quote($scan_lvm_vg_extent_size).", 
     scan_lvm_vg_size        = ".$anvil->Database->quote($scan_lvm_vg_size).", 
     scan_lvm_vg_free        = ".$anvil->Database->quote($scan_lvm_vg_free).", 
-    modified_date           = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date           = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_lvm_vg_uuid        = ".$anvil->Database->quote($scan_lvm_vg_uuid)." 
 ;";
@@ -589,7 +589,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_lvm_vg_attributes).", 
     ".$anvil->Database->quote($scan_lvm_vg_size).", 
     ".$anvil->Database->quote($scan_lvm_vg_free).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 			$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});
@@ -622,7 +622,7 @@ UPDATE
     scan_lvm_vgs
 SET 
     scan_lvm_vg_name = 'DELETED',
-    modified_date    = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date    = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_lvm_vg_uuid = ".$anvil->Database->quote($scan_lvm_vg_uuid)."
 ;";
@@ -806,7 +806,7 @@ SET
     scan_lvm_pv_attributes = ".$anvil->Database->quote($scan_lvm_pv_attributes).", 
     scan_lvm_pv_size       = ".$anvil->Database->quote($scan_lvm_pv_size).", 
     scan_lvm_pv_free       = ".$anvil->Database->quote($scan_lvm_pv_free).", 
-    modified_date          = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date          = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_lvm_pv_uuid       = ".$anvil->Database->quote($scan_lvm_pv_uuid)." 
 ;";
@@ -856,7 +856,7 @@ INSERT INTO
     ".$anvil->Database->quote($scan_lvm_pv_attributes).", 
     ".$anvil->Database->quote($scan_lvm_pv_size).", 
     ".$anvil->Database->quote($scan_lvm_pv_free).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
 			$anvil->Database->write({query => $query, source => $THIS_FILE, line => __LINE__});
@@ -890,7 +890,7 @@ UPDATE
     scan_lvm_pvs
 SET 
     scan_lvm_pv_name = 'DELETED',
-    modified_date    = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date    = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_lvm_pv_uuid = ".$anvil->Database->quote($scan_lvm_pv_uuid)."
 ;";

--- a/scancore-agents/scan-storcli/scan-storcli
+++ b/scancore-agents/scan-storcli/scan-storcli
@@ -988,7 +988,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_drive_group_read_cache).", 
     ".$anvil->Database->quote($new_drive_group_scheduled_cc).", 
     ".$anvil->Database->quote($new_drive_group_write_cache).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			# Now record the query in the array
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1044,7 +1044,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					# Now record the query in the array
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1186,7 +1186,7 @@ SET
     scan_storcli_drive_group_read_cache         = ".$anvil->Database->quote($new_drive_group_read_cache).", 
     scan_storcli_drive_group_scheduled_cc       = ".$anvil->Database->quote($new_drive_group_scheduled_cc).", 
     scan_storcli_drive_group_write_cache        = ".$anvil->Database->quote($new_drive_group_write_cache).", 
-    modified_date                          = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                          = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_drive_group_uuid               = ".$anvil->Database->quote($scan_storcli_drive_group_uuid)." 
 ;";
@@ -1259,7 +1259,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = ".$anvil->Database->quote($new_variable_value).", 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -1308,7 +1308,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($new_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 						# Now record the query in the array
 						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1362,7 +1362,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = 'VANISHED', 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -1687,7 +1687,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_drives_per_span).", 
     ".$anvil->Database->quote($new_span_depth).", 
     ".$anvil->Database->quote($new_scsi_naa_id).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			# Now record the query in the array
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1743,7 +1743,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					# Now record the query in the array
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -1887,7 +1887,7 @@ SET
     scan_storcli_virtual_drive_drives_per_span   = ".$anvil->Database->quote($new_drives_per_span).", 
     scan_storcli_virtual_drive_span_depth        = ".$anvil->Database->quote($new_span_depth).", 
     scan_storcli_virtual_drive_scsi_naa_id       = ".$anvil->Database->quote($new_scsi_naa_id).", 
-    modified_date                                = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                                = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_virtual_drive_uuid              = ".$anvil->Database->quote($scan_storcli_virtual_drive_uuid)." 
 ;";
@@ -1994,7 +1994,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = ".$anvil->Database->quote($new_variable_value).", 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -2044,7 +2044,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($new_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 						# Now record the query in the array
 						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -2099,7 +2099,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = 'VANISHED', 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -2170,7 +2170,7 @@ UPDATE
     scan_storcli_virtual_drives
 SET 
     scan_storcli_virtual_drive_creation_date = 'VANISHED', 
-    modified_date                            = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                            = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_virtual_drive_uuid          = ".$anvil->Database->quote($scan_storcli_virtual_drive_uuid)." 
 ;";
@@ -2260,7 +2260,7 @@ UPDATE
     scan_storcli_drive_groups
 SET 
     scan_storcli_drive_group_access = 'VANISHED', 
-    modified_date                   = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                   = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_drive_group_uuid   = ".$anvil->Database->quote($scan_storcli_drive_group_uuid)." 
 ;";
@@ -2353,7 +2353,7 @@ UPDATE
     scan_storcli_physical_drives
 SET 
     scan_storcli_physical_drive_model = 'VANISHED', 
-    modified_date                     = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                     = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_physical_drive_uuid  = ".$anvil->Database->quote($scan_storcli_physical_drive_uuid)." 
 ;";
@@ -2591,7 +2591,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_vendor).", 
     ".$anvil->Database->quote($new_model).", 
     ".$anvil->Database->quote($new_self_encrypting_drive).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 		# Now record the query in the array
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -2754,7 +2754,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 				# Now record the query in the array
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -2883,7 +2883,7 @@ SET
     scan_storcli_physical_drive_vendor                = ".$anvil->Database->quote($new_vendor).", 
     scan_storcli_physical_drive_model                 = ".$anvil->Database->quote($new_model).", 
     scan_storcli_physical_drive_self_encrypting_drive = ".$anvil->Database->quote($new_self_encrypting_drive).", 
-    modified_date                                     = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                                     = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_physical_drive_uuid                  = ".$anvil->Database->quote($scan_storcli_physical_drive_uuid)." 
 ;";
@@ -3298,7 +3298,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = ".$anvil->Database->quote($new_variable_value).", 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -3347,7 +3347,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($new_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					# Now record the query in the array
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -3402,7 +3402,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = 'VANISHED', 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -3621,7 +3621,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_design_capacity).", 
     ".$anvil->Database->quote($new_manufacture_date).", 
     ".$anvil->Database->quote($new_replacement_needed).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			# Now record the query in the array
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -3786,7 +3786,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					# Now record the query in the array
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -3905,7 +3905,7 @@ SET
     scan_storcli_cachevault_manufacture_date   = ".$anvil->Database->quote($new_manufacture_date).", 
     scan_storcli_cachevault_design_capacity    = ".$anvil->Database->quote($new_design_capacity).", 
     scan_storcli_cachevault_replacement_needed = ".$anvil->Database->quote($new_replacement_needed).", 
-    modified_date                              = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                              = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_cachevault_uuid               = ".$anvil->Database->quote($cachevault_uuid)." 
 ;";
@@ -4318,7 +4318,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = ".$anvil->Database->quote($new_variable_value).", 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -4367,7 +4367,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($new_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 						# Now record the query in the array
 						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -4422,7 +4422,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = 'VANISHED', 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -4485,7 +4485,7 @@ UPDATE
     scan_storcli_cachevaults
 SET 
     scan_storcli_cachevault_state = 'VANISHED', 
-    modified_date                 = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                 = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_cachevault_uuid  = ".$anvil->Database->quote($cachevault_uuid)." 
 ;";
@@ -4727,7 +4727,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_design_capacity).", 
     ".$anvil->Database->quote($new_manufacture_date).", 
     ".$anvil->Database->quote($new_replacement_needed).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			# Now record the query in the array
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -4890,7 +4890,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					# Now record the query in the array
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -5008,7 +5008,7 @@ SET
     scan_storcli_bbu_manufacture_date   = ".$anvil->Database->quote($new_manufacture_date).", 
     scan_storcli_bbu_design_capacity    = ".$anvil->Database->quote($new_design_capacity).", 
     scan_storcli_bbu_replacement_needed = ".$anvil->Database->quote($new_replacement_needed).", 
-    modified_date                       = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                       = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_bbu_uuid               = ".$anvil->Database->quote($bbu_uuid)." 
 ;";
@@ -5446,7 +5446,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = ".$anvil->Database->quote($new_variable_value).", 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -5496,7 +5496,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($new_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 						# Now record the query in the array
 						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -5551,7 +5551,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = 'VANISHED', 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -5613,7 +5613,7 @@ UPDATE
     scan_storcli_bbus
 SET 
     scan_storcli_bbu_state = 'VANISHED', 
-    modified_date          = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date          = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_bbu_uuid  = ".$anvil->Database->quote($bbu_uuid)." 
 ;";
@@ -5790,7 +5790,7 @@ INSERT INTO
     ".$anvil->Database->quote($new_model).", 
     ".$anvil->Database->quote($new_alarm_state).", 
     ".$anvil->Database->quote($new_cache_size).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 			# Now record the query in the array
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -5946,7 +5946,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 					# Now record the query in the array
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -6024,7 +6024,7 @@ SET
     scan_storcli_controller_model         = ".$anvil->Database->quote($new_model).", 
     scan_storcli_controller_alarm_state   = ".$anvil->Database->quote($new_alarm_state).", 
     scan_storcli_controller_cache_size    = ".$anvil->Database->quote($new_cache_size).", 
-    modified_date                         = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                         = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_controller_host_uuid     = ".$anvil->Database->quote($anvil->Get->host_uuid)." 
 AND 
@@ -6480,7 +6480,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = ".$anvil->Database->quote($new_variable_value).", 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -6530,7 +6530,7 @@ INSERT INTO
     ".$anvil->Database->quote($temperature).", 
     ".$anvil->Database->quote($variable).", 
     ".$anvil->Database->quote($new_variable_value).", 
-    ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 );";
 						# Now record the query in the array
 						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { query => $query }});
@@ -6585,7 +6585,7 @@ UPDATE
     scan_storcli_variables 
 SET 
     scan_storcli_variable_value = 'VANISHED', 
-    modified_date               = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date               = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_variable_uuid  = ".$anvil->Database->quote($variable_uuid)."
 ;";
@@ -6647,7 +6647,7 @@ UPDATE
     scan_storcli_controllers
 SET 
     scan_storcli_controller_alarm_state = 'VANISHED', 
-    modified_date                       = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})."
+    modified_date                       = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)."
 WHERE 
     scan_storcli_controller_host_uuid   = ".$anvil->Database->quote($anvil->Get->host_uuid)." 
 AND 

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -125,7 +125,7 @@ if (not $anvil->data->{sys}{database}{connections})
 			sleep 10;
 			
 			$anvil->refresh();
-			$anvil->Database->connect({debug => 3, check_if_configured => 1});
+			$anvil->Database->connect({check_if_configured => 1, check_for_resync => 1});
 			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 3, key => "log_0132"});
 			if (not $anvil->data->{sys}{database}{connections})
 			{
@@ -202,7 +202,7 @@ while(1)
 	# If, so some reason, anvil.conf is lost, create it.
 	$anvil->System->_check_anvil_conf();
 	
-	$anvil->Database->connect({check_if_configured => $check_if_database_is_configured});
+	$anvil->Database->connect({check_if_configured => $check_if_database_is_configured, check_for_resync => 1});
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 3, key => "log_0132"});
 	
 	# Mark that we don't want to check the database now.
@@ -915,7 +915,7 @@ AND
 	else
 	{
 		# Update our status 
-		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 2, key => "log_0572"});
+		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 0, level => 2, key => "log_0572"});
 		
 		$anvil->Database->get_hosts({debug => 2});
 		my $host_uuid = $anvil->Get->host_uuid({debug => 2});
@@ -1322,7 +1322,11 @@ sub update_state_file
 	
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 3, key => "log_0480"});
 	
-	my ($states_output, $return_code) = $anvil->System->call({debug => 3, shell_call => $anvil->data->{path}{exe}{'anvil-update-states'}.$anvil->Log->switches, source => $THIS_FILE, line => __LINE__});
+	#my $shell_call = $anvil->data->{path}{exe}{'anvil-update-states'}.$anvil->Log->switches;
+	my $shell_call = $anvil->data->{path}{exe}{'anvil-update-states'};
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+	
+	my ($states_output, $return_code) = $anvil->System->call({debug => 3, shell_call => $shell_call, source => $THIS_FILE, line => __LINE__});
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
 		states_output => $states_output,
 		return_code   => $return_code, 

--- a/tools/anvil-delete-server
+++ b/tools/anvil-delete-server
@@ -187,7 +187,7 @@ UPDATE
     servers 
 SET 
     server_state  = 'DELETED', 
-    modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     server_uuid   = ".$anvil->Database->quote($server_uuid)."
 ;";

--- a/tools/anvil-manage-server
+++ b/tools/anvil-manage-server
@@ -128,7 +128,7 @@ $anvil->nice_exit({exit_code => 0});
 
 
 
-
+=cut
 # Make sure we're in an Anvil!
 $anvil->data->{sys}{anvil_uuid} = $anvil->Cluster->get_anvil_uuid();
 $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
@@ -201,7 +201,7 @@ if ((not $anvil->data->{sys}{server_name}) or (not $anvil->data->{sys}{server_uu
 
 # Show the server's existing stats.
 show_stats($anvil);
-
+=cut
 
 $anvil->nice_exit({exit_code => 0});
 
@@ -223,8 +223,22 @@ sub interactive_question
 {
 	my ($anvil) = @_;
 	
+	$anvil->Database->get_hosts();
 	$anvil->Database->get_anvils();
 	$anvil->Database->get_servers();
+	
+	$anvil->data->{target_server}{server_uuid}           = "" if not defined $anvil->data->{target_server}{server_uuid};
+	$anvil->data->{target_server}{server_name}           = "" if not defined $anvil->data->{target_server}{server_name};
+	$anvil->data->{target_server}{server_state}          = "" if not defined $anvil->data->{target_server}{server_state};
+	$anvil->data->{target_server}{anvil_uuid}            = "" if not defined $anvil->data->{target_server}{anvil_uuid};
+	$anvil->data->{target_server}{anvil_name}            = "" if not defined $anvil->data->{target_server}{anvil_name};
+	$anvil->data->{target_server}{anvil_description}     = "" if not defined $anvil->data->{target_server}{anvil_description};
+	$anvil->data->{target_server}{anvil_node1_host_uuid} = "" if not defined $anvil->data->{target_server}{anvil_node1_host_uuid};
+	$anvil->data->{target_server}{anvil_node1_host_name} = "" if not defined $anvil->data->{target_server}{anvil_node1_host_name};
+	$anvil->data->{target_server}{anvil_node2_host_uuid} = "" if not defined $anvil->data->{target_server}{anvil_node2_host_uuid};
+	$anvil->data->{target_server}{anvil_node2_host_name} = "" if not defined $anvil->data->{target_server}{anvil_node2_host_name};
+	$anvil->data->{target_server}{anvil_dr1_host_uuid}   = "" if not defined $anvil->data->{target_server}{anvil_dr1_host_uuid};
+	$anvil->data->{target_server}{anvil_dr1_host_name}   = "" if not defined $anvil->data->{target_server}{anvil_dr1_host_name};
 	
 	### Server
 	# First, has the user specified a server? If so, and if it's by name, make sure it's unique. If the 
@@ -248,41 +262,140 @@ sub interactive_question
 		}
 	}
 	
-	# Do we know or can we find the Anvil! UUID?
-	$anvil->data->{target_server}{server_uuid} = $anvil->data->{switches}{'server-uuid'} ? $anvil->data->{switches}{'server-uuid'} : "";
-	$anvil->data->{target_server}{server_name} = $anvil->data->{switches}{'server-name'} ? $anvil->data->{switches}{'server-name'} : "";
-	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
-		"target_server::server_uuid" => $anvil->data->{target_server}{server_uuid},
-		"target_server::server_name" => $anvil->data->{target_server}{server_name},
-	}});
-	
 	# If we have a server UUID, make sure it's valid.
-	if $anvil->data->{target_server}{server_uuid})
+	if ($anvil->data->{target_server}{server_uuid})
 	{
 		# Pull up the server data.
 		my $server_uuid = $anvil->data->{target_server}{server_uuid};
 		if (exists $anvil->data->{servers}{server_uuid}{$server_uuid})
 		{
 			# We can divine everthing from this.
-			$anvil->data->{target_server}{server_name} = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_name};
+			my $anvil_uuid       = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_anvil_uuid};
+			my $server_host_uuid = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_host_uuid};
+			my $node1_host_uuid  = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_node1_host_uuid};
+			my $node2_host_uuid  = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_node1_host_uuid};
+			my $dr1_host_uuid    = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_dr1_host_uuid};
 			
+			$anvil->data->{target_server}{server_name}           = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_name};
+			$anvil->data->{target_server}{server_state}          = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_state};
+			$anvil->data->{target_server}{anvil_uuid}            = $anvil_uuid;
+			$anvil->data->{target_server}{anvil_name}            = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_name};
+			$anvil->data->{target_server}{anvil_description}     = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_description};
+			$anvil->data->{target_server}{anvil_node1_host_uuid} = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_node1_host_uuid};
+			$anvil->data->{target_server}{anvil_node1_host_name} = $anvil->data->{hosts}{host_uuid}{$node1_host_uuid}{host_name};
+			$anvil->data->{target_server}{anvil_node2_host_uuid} = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_node2_host_uuid};
+			$anvil->data->{target_server}{anvil_node2_host_name} = $anvil->data->{hosts}{host_uuid}{$node2_host_uuid}{host_name};
+			$anvil->data->{target_server}{anvil_dr1_host_uuid}   = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_node1_host_uuid};
+			$anvil->data->{target_server}{anvil_dr1_host_name}   = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_node1_host_uuid};
+			if ($dr1_host_uuid)
+			{
+				$anvil->data->{target_server}{anvil_dr1_host_uuid} = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_dr1_host_uuid};
+				$anvil->data->{target_server}{anvil_dr1_host_name} = $anvil->data->{hosts}{host_uuid}{$dr1_host_uuid}{host_name};;
+			}
+			
+			### Pull out details pf the server. 
+			# How much RAM are we using and how much is configured?
+			$anvil->data->{target_server}{server_ram_in_use} = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_ram_in_use};
+			$anvil->data->{target_server}{server_host_uuid}  = $server_host_uuid;
+			$anvil->data->{target_server}{server_host_name}  = $anvil->data->{hosts}{host_uuid}{$server_host_uuid}{host_name};
+			if ($anvil->data->{target_server}{server_state} eq "shut off")
+			{
+				$anvil->data->{target_server}{server_ram_in_use} = 0;
+				$anvil->data->{target_server}{server_host_uuid}  = "";
+				$anvil->data->{target_server}{server_host_name}  = "";
+			}
+			$anvil->data->{target_server}{server_configured_ram}          = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_configured_ram};
+			$anvil->data->{target_server}{server_start_after_server_uuid} = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_start_after_server_uuid};
+			$anvil->data->{target_server}{server_start_after_server_name} = "";
+			$anvil->data->{target_server}{server_start_delay}             = 0;
+			if ($anvil->data->{target_server}{server_start_after_server_uuid})
+			{
+				my $server_start_after_server_uuid                               = $anvil->data->{target_server}{server_start_after_server_uuid};
+				   $anvil->data->{target_server}{server_start_after_server_name} = $anvil->data->{servers}{server_uuid}{$server_start_after_server_uuid}{server_name};
+				   $anvil->data->{target_server}{server_start_delay}             = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_start_delay};
+			}
+			
+			# Get a list of files on this Anvil!
+			foreach my $file_uuid (keys %{$anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}})
+			{
+				my $file_name      = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_name};
+				my $file_directory = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_directory};
+				my $file_size      = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_size};
+				my $file_md5sum    = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_md5sum};
+				my $file_type      = $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_type};
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					file_name      => $file_name, 
+					file_directory => $file_directory, 
+					file_size      => $anvil->Convert->bytes_to_human_readable({'bytes' => $file_size})." (".$anvil->Convert->add_commas({number => $file_size}).")", 
+					file_md5sum    => $file_md5sum, 
+					file_type      => $file_type, 
+				}});
+				
+				if ($file_type eq "iso")
+				{
+					# ISO image
+				}
+				else
+				{
+					# (Potential) script
+				}
+			}
+			
+# 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
+# 				"anvils::anvil_uuid::${anvil_uuid}::file_uuid::${file_uuid}::file_name"      => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_name}, 
+# 				"anvils::anvil_uuid::${anvil_uuid}::file_uuid::${file_uuid}::file_directory" => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_directory}, 
+# 				"anvils::anvil_uuid::${anvil_uuid}::file_uuid::${file_uuid}::file_size"      => $anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_size}})." (".$anvil->Convert->add_commas({number => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_size}}).")", 
+# 				"anvils::anvil_uuid::${anvil_uuid}::file_uuid::${file_uuid}::file_md5sum"    => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_md5sum}, 
+# 				"anvils::anvil_uuid::${anvil_uuid}::file_uuid::${file_uuid}::file_type"      => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_type}, 
+# 			}});
+# 			
+# 				"servers::server_uuid::${server_uuid}::server_pre_migration_file_uuid"  => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_pre_migration_file_uuid}, 
+# 				"servers::server_uuid::${server_uuid}::server_pre_migration_arguments"  => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_pre_migration_arguments}, 
+# 				"servers::server_uuid::${server_uuid}::server_post_migration_file_uuid" => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_post_migration_file_uuid}, 
+# 				"servers::server_uuid::${server_uuid}::server_post_migration_arguments" => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_post_migration_arguments}, 
+# 			
+# 			
+# 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
+# 				"hosts::host_uuid::${host_uuid}::host_name"       => $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_name}, 
+# 				"hosts::host_uuid::${host_uuid}::short_host_name" => $anvil->data->{hosts}{host_uuid}{$host_uuid}{short_host_name}, 
+# 				"hosts::host_uuid::${host_uuid}::host_type"       => $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_type}, 
+# 				"hosts::host_uuid::${host_uuid}::host_key"        => $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_key}, 
+# 				"hosts::host_uuid::${host_uuid}::host_ipmi"       => $host_ipmi =~ /passw/ ? $anvil->Log->is_secure($anvil->data->{hosts}{host_uuid}{$host_uuid}{host_ipmi}) : $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_ipmi}, 
+# 				"hosts::host_uuid::${host_uuid}::host_status"     => $anvil->data->{hosts}{host_uuid}{$host_uuid}{host_status}, 
+# 				"hosts::host_uuid::${host_uuid}::anvil_name"      => $anvil->data->{hosts}{host_uuid}{$host_uuid}{anvil_name}, 
+# 				"hosts::host_uuid::${host_uuid}::anvil_uuid"      => $anvil->data->{hosts}{host_uuid}{$host_uuid}{anvil_uuid}, 
+# 			}});
+# 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
+# 				"anvils::anvil_uuid::${anvil_uuid}::anvil_name"            => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_name}, 
+# 				"anvils::anvil_uuid::${anvil_uuid}::anvil_description"     => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_description}, 
+# 				"anvils::anvil_uuid::${anvil_uuid}::anvil_password"        => $anvil->Log->is_secure($anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_password}), 
+# 				"anvils::anvil_uuid::${anvil_uuid}::anvil_node1_host_uuid" => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_node1_host_uuid}, 
+# 				"anvils::anvil_uuid::${anvil_uuid}::anvil_node2_host_uuid" => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_node2_host_uuid}, 
+# 				"anvils::anvil_uuid::${anvil_uuid}::anvil_dr1_host_uuid"   => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{anvil_dr1_host_uuid}, 
+# 			}});
+# 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
+# 				"servers::server_uuid::${server_uuid}::server_anvil_uuid"               => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_anvil_uuid}, 
+# 				"servers::server_uuid::${server_uuid}::server_user_stop"                => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_user_stop}, 
+# 				"servers::server_uuid::${server_uuid}::server_start_after_server_uuid"  => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_start_after_server_uuid}, 
+# 				"servers::server_uuid::${server_uuid}::server_start_delay"              => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_start_delay}, 
+# 				"servers::server_uuid::${server_uuid}::server_host_uuid"                => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_host_uuid}, 
+# 				"servers::server_uuid::${server_uuid}::server_state"                    => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_state}, 
+# 				"servers::server_uuid::${server_uuid}::server_live_migration"           => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_live_migration}, 
+# 				"servers::server_uuid::${server_uuid}::server_pre_migration_file_uuid"  => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_pre_migration_file_uuid}, 
+# 				"servers::server_uuid::${server_uuid}::server_pre_migration_arguments"  => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_pre_migration_arguments}, 
+# 				"servers::server_uuid::${server_uuid}::server_post_migration_file_uuid" => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_post_migration_file_uuid}, 
+# 				"servers::server_uuid::${server_uuid}::server_post_migration_arguments" => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_post_migration_arguments}, 
+# 				"servers::server_uuid::${server_uuid}::server_ram_in_use"               => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_ram_in_use}, 
+# 				"servers::server_uuid::${server_uuid}::server_configured_ram"           => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_configured_ram}, 
+# 				"servers::server_uuid::${server_uuid}::server_updated_by_user"          => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_updated_by_user}, 
+# 				"servers::server_uuid::${server_uuid}::server_boot_time"                => $anvil->data->{servers}{server_uuid}{$server_uuid}{server_boot_time}, 
+# 			}});
 			
 			
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 				"target_server::server_name" => $anvil->data->{target_server}{server_name},
 			}});
 		}
-	}
-	
-	if (not $anvil->data->{target_server}{server_name})
-	{
-		$anvil->data->{target_server}{server_name} = $anvil->Cluster->get_server_name({server_uuid => $anvil->data->{target_server}{server_uuid}});
-		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { "target_server::server_name" => $anvil->data->{target_server}{server_name} }});
-	}
-	elsif (not $anvil->data->{target_server}{server_uuid})
-	{
-		$anvil->data->{target_server}{server_uuid} = $anvil->Cluster->get_server_uuid({server_name => $anvil->data->{target_server}{server_name}});
-		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { "target_server::server_uuid" => $anvil->data->{target_server}{server_uuid} }});
 	}
 	
 	### Anvil

--- a/tools/anvil-rename-server
+++ b/tools/anvil-rename-server
@@ -672,7 +672,7 @@ UPDATE
     servers 
 SET 
     server_name   = ".$anvil->Database->quote($new_server_name).", 
-    modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     server_uuid   = ".$anvil->Database->quote($anvil->data->{switches}{'server-uuid'})."
 ;";

--- a/tools/anvil-update-states
+++ b/tools/anvil-update-states
@@ -32,10 +32,6 @@ if (not $anvil->data->{sys}{database}{connections})
 	# No database, but we need to keep going. If the user unplugged the only cable connecting us to the
 	# network, we'll lose all DBs, but we still need to record the order the NICs went up and down.
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, 'print' => 1, key => "warning_0016"});
-	
-	# Generate our own time stamp
-	$anvil->data->{sys}{database}{timestamp} =  $anvil->Get->date_and_time({use_utc => 1});
-	$anvil->data->{sys}{database}{timestamp} =~ s/\//-/g;
 }
 
 process_interface_cache($anvil);
@@ -467,7 +463,7 @@ sub update_network
 			# If this is a link and there's no database connections, cache the data.
 			if (($type eq "interface") && (not $anvil->data->{sys}{database}{connections}))
 			{
-				$anvil->data->{cache}{new_file} .= $interface.",".$anvil->data->{sys}{database}{timestamp}.",".$mac_address.",".$speed.",".$link_state.",".$operational."\n";
+				$anvil->data->{cache}{new_file} .= $interface.",".$anvil->Database->refresh_timestamp.",".$mac_address.",".$speed.",".$link_state.",".$operational."\n";
 				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { 
 					"cache::new_file" => $anvil->data->{cache}{new_file},
 				}});

--- a/tools/striker-purge-target
+++ b/tools/striker-purge-target
@@ -272,7 +272,7 @@ UPDATE
     anvils 
 SET 
     ".$host_key." = NULL, 
-    modified_date = ".$anvil->Database->quote($anvil->data->{sys}{database}{timestamp})." 
+    modified_date = ".$anvil->Database->quote($anvil->Database->refresh_timestamp)." 
 WHERE 
     anvil_uuid    = ".$anvil->Database->quote($anvil_uuid)."
 ;";


### PR DESCRIPTION
… All INSERT and UPDATE calls now generate a new timestamp via Database->refresh_timestamp, instead of using 'sys::database::timestamp'. This was done in responce to finding a bug where tables in a database differed in both counts of public and private schemas (ip_addresses table, specifically) that failed to resync because the timestamps were re-used too often.

* WIP - Continuing work on the new anvil-manage-server tool.
* Updated Database->get_anvils() to load information on the files available on each Anvil! system.
* Updated Database->insert_or_update_network_interfaces() to no longer take the 'timestamp' parameter.
* Removed all logging from Database->refresh_timestamp() to speed it up, given how often it will be called now.

Signed-off-by: Digimer <digimer@alteeve.ca>