### PR TITLE
* Created Network->check_bonds() that checks to see if any bonds are …

### DIFF
--- a/share/words.xml
+++ b/share/words.xml
@@ -1817,6 +1817,10 @@ The file: [#!variable!file!#] needs to be updated. The difference is:
 ====
 </key>
 		<key name="log_0626">This system will reboot in: [#!variable!seconds!#] seconds...</key>
+		<key name="log_0627">The bond: [#!variable!bond!#] is completely down, trying to recover member interfaces.</key>
+		<key name="log_0628">The bond: [#!variable!bond!#] is up, but at least one interface is down. Will try to recover now.</key>
+		<key name="log_0629">The bond: [#!variable!bond!#]'s interface: [#!variable!interface!#] is not in this bond. Trying to bring it up now...</key>
+		<key name="log_0630">The bond: [#!variable!bond!#] will now be brought up (even if it already is up).</key>
 		
 		<!-- Messages for users (less technical than log entries), though sometimes used for logs, too. -->
 		<key name="message_0001">The host name: [#!variable!target!#] does not resolve to an IP address.</key>

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -449,6 +449,9 @@ sub handle_periodic_tasks
 			}
 		}
 		
+		# Check that bonds are up. Degraded bonds will be left alone.
+		$anvil->Network->check_bonds({heal => "down_only"});
+		
 		# Check mail server config.
 		my $problem = $anvil->Email->check_config({debug => 3});
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { problem => $problem }});
@@ -587,6 +590,9 @@ sub run_once
 	
 	# Check that the daemons we need are running.
 	check_daemons($anvil);
+	
+	# In some cases, bonds don't come up with their links. This checks/heals that.
+	$anvil->Network->check_bonds({heal => "all"});
 	
 	# Check the ssh stuff. 
 	# NOTE: This actually runs again in the minutes tasks, but needs to run on boot as well.

--- a/tools/anvil-watch-bonds
+++ b/tools/anvil-watch-bonds
@@ -58,6 +58,7 @@ $anvil->data->{colours} = {
 		{
 			is_primary	=>	"bold green", 
 			is_other	=>	"yellow",
+			none		=>	"bold red", 
 		},
 		bond_name	=>	"bold cyan",
 		duplex		=>	{
@@ -171,6 +172,7 @@ $anvil->data->{colours} = {
 # 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, priority => "err", key => "error_0003"});
 # 	$anvil->nice_exit({exit_code => 1});
 # }
+$anvil->data->{switches}{'run-once'} = "";
 $anvil->Get->switches();
 
 while(1)
@@ -227,6 +229,9 @@ while(1)
 			"bond::${bond_name}::mac_address"        => $anvil->data->{bond}{$bond_name}{mac_address},
 			"bond::${bond_name}::mac_address_colour" => $anvil->data->{bond}{$bond_name}{mac_address_colour}, 
 		}});
+		
+		# Set some defaults that may not be found.
+		$anvil->data->{bond}{$bond_name}{primary_slave} = "None";
 		
 		my $bond_body = $anvil->Storage->read_file({file => $full_path});
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
@@ -612,7 +617,14 @@ while(1)
 		my $active_slave_colour = $anvil->data->{colours}{bond}{active_iface}{is_primary};
 		if ($primary_slave ne $active_slave)
 		{
-			$active_slave_colour = $anvil->data->{colours}{bond}{active_iface}{is_other};
+			if ($active_slave eq "None")
+			{
+				$active_slave_colour = $anvil->data->{colours}{bond}{active_iface}{none};
+			}
+			else
+			{
+				$active_slave_colour = $anvil->data->{colours}{bond}{active_iface}{is_other};
+			}
 		}
 		
 		my $centered_bond_name    = $anvil->Words->center_text({string => $bond_name,    width => $name_length});
@@ -665,6 +677,11 @@ while(1)
 		}
 	}
 	print $divider_line."\n";
+	
+	if ($anvil->data->{switches}{'run-once'})
+	{
+		$anvil->nice_exit({exit_code => 0});
+	}
 	print $anvil->Words->string({key => "header_0061"})."\n";
 	sleep 2;
 }


### PR DESCRIPTION
…down, or if any interfaces configured to be in a bond are not actually in it. It accepts a 'heal' parameter that, by default, will bring up a bond with no active links, but leaves degraded bonds alone. It call also take 'all' and will try to bring up any missing interfaces. This distinction exists so that if a link is flaky and someone takes it down manually until it can be repaired, it doesn't get turned back on.

* Updated anvil-daemon to call Network->check_bonds() with 'all' on startup, then woth 'down_only' once per minute to try to heal down'ed bonds.
* Updated anvil-watch-bonds to take a 'run-once' switch and exit after one report, if set.

Signed-off-by: Digimer <digimer@alteeve.ca>