### PR TITLE
* Added Cluster->manage_fence_delay() that reports back and, optional…

### DIFF
--- a/Anvil/Tools/Server.pm
+++ b/Anvil/Tools/Server.pm
@@ -1986,7 +1986,8 @@ WHERE
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { stop_waiting => $stop_waiting }});
 	};
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { wait_time => $wait_time }});
-	until($success)
+	my $waiting = 1;
+	while ($waiting)
 	{
 		# Update
 		$anvil->Server->find({debug => $debug});
@@ -2007,7 +2008,11 @@ WHERE
 		{
 			# Success!
 			$success = 1;
-			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0426", variables => { server => $server }});
+			$waiting = 0;
+			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0426", variables => { 
+				server  => $server,
+				waiting => $waiting, 
+			}});
 			
 			# Mark it as stopped now. (if we have a server_uuid, we have a database connection)
 			if ($server_uuid)
@@ -2042,9 +2047,12 @@ WHERE
 		if (($stop_waiting) && (time > $stop_waiting))
 		{
 			# Give up waiting.
+			$waiting = 0;
+			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0426", variables => { waiting => $waiting }});
+			
 			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, priority => "err", key => "log_0427", variables => { 
-				server    => $server,
-				wait_time => $wait_time,
+				server => $server,
+				'wait' => $wait_time,
 			}});
 		}
 		else

--- a/scancore-agents/scan-cluster/scan-cluster
+++ b/scancore-agents/scan-cluster/scan-cluster
@@ -15,7 +15,6 @@
 # TODO: 
 # - When a node is lost, update the location constraints to keep the servers on the surviving node when the
 #   peer returns.
-# - Test that the fence delay favours the host that has all the servers.
 # 
 
 use strict;
@@ -104,11 +103,144 @@ find_changes($anvil);
 # Check the cluster config.
 check_config($anvil);
 
+# Check the fence delay
+check_fence_delay($anvil);
+
 $anvil->nice_exit({exit_code => 0});
 
 #############################################################################################################
 # Functions                                                                                                 #
 #############################################################################################################
+
+# Check to see if we need to move the fence delay.
+sub check_fence_delay
+{
+	my ($anvil) = @_;
+	
+	my $preferred_node = $anvil->Cluster->manage_fence_delay();
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { preferred_node => $preferred_node }});
+	if ($preferred_node ne "!!error!!")
+	{
+		### NOTE: We don't make the peer be the preferred node, a node can only make itself the preferred 
+		###       node.
+		# How many servers are running on each node.
+		$anvil->Database->get_anvils();
+		$anvil->Database->get_servers();
+		$anvil->Cluster->get_peers();
+		my $anvil_uuid      = $anvil->Cluster->get_anvil_uuid();
+		my $local_node_is   = $anvil->data->{sys}{anvil}{i_am};
+		my $local_node_name = $anvil->data->{cib}{parsed}{'local'}{name};
+		my $local_host_name = $anvil->data->{sys}{anvil}{$local_node_is}{host_name};
+		my $local_host_uuid = $anvil->data->{sys}{anvil}{$local_node_is}{host_uuid};
+		my $peer_node_is    = $anvil->data->{sys}{anvil}{peer_is};
+		my $peer_node_name  = $anvil->data->{cib}{parsed}{peer}{name};;
+		my $peer_host_name  = $anvil->data->{sys}{anvil}{$peer_node_is}{host_name};
+		my $peer_host_uuid  = $anvil->data->{sys}{anvil}{$peer_node_is}{host_uuid};
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			anvil_uuid      => $anvil_uuid,
+			local_node_is   => $local_node_is, 
+			local_node_name => $local_node_name, 
+			local_host_name => $local_host_name, 
+			local_host_uuid => $local_host_uuid, 
+			peer_node_is    => $peer_node_is, 
+			peer_node_name  => $peer_node_name, 
+			peer_host_name  => $peer_host_name, 
+			peer_host_uuid  => $peer_host_uuid, 
+		}});
+		
+		# Get the short host names, as that's usually what the node name is.
+		my $local_short_host_name =  $local_host_name;
+		$local_short_host_name =~ s/\..$//;
+		my $peer_short_host_name  =  $peer_host_name;
+		$peer_short_host_name  =~ s/\..$//;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			local_short_host_name => $local_short_host_name, 
+			peer_short_host_name  => $peer_short_host_name, 
+		}});
+		
+		# If my peer isn't in the cluster, make sure I am the fence delay host.
+		if (not $anvil->data->{cib}{parsed}{peer}{ready})
+		{
+			# My peer is not ready, make sure I'm the preferred host.
+			if (($preferred_node eq $local_node_name) or ($preferred_node eq $local_host_name) && ($preferred_node eq $local_short_host_name))
+			{
+				# We're good.
+				$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0633"});
+			}
+			else
+			{
+				# We're not, set the delay to us.
+				$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0634"});
+				my $preferred_node = $anvil->Cluster->manage_fence_delay({prefer => $local_node_name});
+				return(0);
+			}
+		}
+		
+		# How many servers are on each node?
+		my $local_server_count = 0;
+		my $peer_server_count  = 0;
+		foreach my $server_uuid (keys %{$anvil->data->{servers}{server_uuid}})
+		{
+			next if $anvil_uuid ne $anvil->data->{servers}{server_uuid}{$server_uuid}{server_anvil_uuid};
+			
+			my $server_name      = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_name};
+			my $server_state     = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_state};
+			my $server_host_uuid = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_host_uuid};
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				server_uuid      => $server_uuid, 
+				server_name      => $server_name, 
+				server_state     => $server_state, 
+				server_host_uuid => $server_host_uuid, 
+			}});
+			next if $server_state eq "shut off";
+			if ($server_state eq "migrating")
+			{
+				# Don't do anything.
+				$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0635", variables => { server_name => $server_name }});
+				return(0);
+			}
+			if ($server_host_uuid eq $local_host_uuid)
+			{
+				$local_server_count++;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { local_server_count => $local_server_count }});
+			}
+			elsif ($server_host_uuid eq $peer_host_uuid)
+			{
+				$peer_server_count++;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { peer_server_count => $peer_server_count }});
+			}
+		}
+		
+		# Don't do anything if there are no servers running anywhere, or if both servers have at least one 
+		# server.
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			local_server_count => $local_server_count, 
+			peer_server_count  => $peer_server_count, 
+		}});
+		if ((not $local_server_count) && (not $peer_server_count))
+		{
+			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0636"});
+			return(0);
+		}
+		elsif (($local_server_count) && ($peer_server_count))
+		{
+			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0637", variables => {
+				local_server_count => $local_server_count,
+				peer_server_count  => $peer_server_count,
+			}});
+			return(0);
+		}
+		elsif (($local_server_count) && ($preferred_node ne $local_node_name))
+		{
+			# Make us the preferred host.
+			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0638"});
+			my $preferred_node = $anvil->Cluster->manage_fence_delay({prefer => $local_node_name});
+			return(0);
+		}
+	}
+	
+	return(0);
+}
 
 sub check_config
 {

--- a/share/words.xml
+++ b/share/words.xml
@@ -420,6 +420,8 @@ The attempt to start the servers appears to have failed. The return code '0' was
 		<key name="error_0306">Unable to connect to the database, unable to provision a server at this time.</key>
 		<key name="error_0307">Failed to perform requested task(s) because the requester is not authenticated.</key>
 		<key name="error_0308"><![CDATA[[ Error ] - The Job: [#!variable!job-uuid!#] appears to have passed malformed data. The raw data was: [#!variable!raw!#]. Expected 'as_machine=<host_type>,manifest_uuid=<manifest_uuid>,anvil_uuid=<anvil_uuid>'. Either the parse failed, or the data was somehow invalid.]]></key>
+		<key name="error_0309">I tried to change the fencing preferred node to: [#!variable!prefer!#], but it doesn't appear to have worked. The preferred node is: [#!variable!current!#] ('--' means there is no preferred node)</key>
+		<key name="error_0310">I tried to remove the fence delay from the node: [#!variable!node!#], but it doesn't appear to have worked. The preferred node is: [#!variable!current!#] ('--' means there is no preferred node)</key>
 		
 		<!-- Files templates -->
 		<!-- NOTE: Translating these files requires an understanding of which lines are translatable -->
@@ -1823,6 +1825,12 @@ The file: [#!variable!file!#] needs to be updated. The difference is:
 		<key name="log_0630">The bond: [#!variable!bond!#] will now be brought up (even if it already is up).</key>
 		<key name="log_0631">Network device names have changed, rebooting to ensure they take effect. The job will restart once the network comes back up.</key>
 		<key name="log_0632">The bridge: [#!variable!bridge!#] is down, tryin to bring it up now.</key>
+		<key name="log_0633">Our peer is offline and we're already the preferred fence node. Nothing to do.</key>
+		<key name="log_0634">Our peer is offline and we're not the preferred fence node. Updating the fence config to prefer this node.</key>
+		<key name="log_0635">The server: [#!variable!server_name!#] is migrating. Skipping fence delay preference checks for now.</key>
+		<key name="log_0636">No servers are running on either node. Skipping fence delay preference checks for now.</key>
+		<key name="log_0637">We've got: [#!variable!local_server_count!#] servers, and the peer has: [#!variable!peer_server_count!#] servers. Skipping fence delay preference checks for now.</key>
+		<key name="log_0638">We're hosting servers, and our peer is not. Making the fence delay favours this node.</key>
 		
 		<!-- Messages for users (less technical than log entries), though sometimes used for logs, too. -->
 		<key name="message_0001">The host name: [#!variable!target!#] does not resolve to an IP address.</key>
@@ -2171,6 +2179,8 @@ Are you sure that you want to delete the server: [#!variable!server_name!#]? [Ty
 		<key name="message_0250">The daemon: [#!variable!daemon!#] was not running, starting it now.</key>
 		<key name="message_0251">Preparing to manage a server.</key>
 		<key name="message_0252">Found the server: [#!variable!server_name!#] in the database, loading details now.</key>
+		<key name="message_0253">The fence delay to prefer the node: [#!variable!node!#] has been removed.</key>
+		<key name="message_0254">The fence delay now prefers the node: [#!variable!node!#].</key>
 		
 		<!-- Success messages shown to the user --> 
 		<key name="ok_0001">Saved the mail server information successfully!</key>
@@ -2802,6 +2812,9 @@ Read UUID: .... [#!variable!read_uuid!#]
 		<key name="warning_0119">[ Warning ] - The 'admin' user was created with the user ID: [#!variable!uid!#].</key>
 		<key name="warning_0120">[ Warning ] - Timed out waiting for the database: [#!variable!uuid!#] to become available.</key>
 		<key name="warning_0121">[ Warning ] - The Anvil! with the UUID: [#!variable!uuid!#] was not found. Exiting, will re-run the anvil-join-anvil job again in a few moments.</key>
+		<key name="warning_0122">[ Warning ] - Asked to find or set the fence delay, but this is not a node.</key>
+		<key name="warning_0123">[ Warning ] - Asked to find or set the fence delay, but node is not in a cluster.</key>
+		<key name="warning_0124">[ Warning ] - Asked to find or set the fence delay, but node is not fully in the cluster yet.</key>
 
 		<!-- The entries below here are not sequential, but use a key to find the entry. -->
 		<!-- Run 'striker-parse-os-list to find new entries. --> 


### PR DESCRIPTION
…ly, sets a preferred node in a fence race.

* Updated scan-cluster to check / set which node should be preferred if a netsplit causes a fence race.
* Fixed a bug in Server->shutdown_virsh() where a shutdown timeout would go into a loop.

Signed-off-by: Digimer <digimer@alteeve.ca>