### PR TITLE
Fix drbd-kmod build corner case

### DIFF
--- a/units/anvil-daemon.service
+++ b/units/anvil-daemon.service
@@ -4,6 +4,7 @@ Wants=network.target
 
 [Service]
 Type=simple
+ExecStartPre=-/bin/sh -c "if [ -f /usr/sbin/akmods ]; then /usr/sbin/modprobe drbd || /usr/sbin/akmods --force; fi"
 ExecStart=/usr/sbin/anvil-daemon
 ExecStop=/bin/kill -WINCH ${MAINPID}
 Restart=always


### PR DESCRIPTION
On fresh install from a CD or an image, it is very likely that a new
kernel is installed on the system. kernel-devel will point to the new
kernel (not the running one) and akmods would fail to build the drbd
kmod.

On reboot, akmods run before Network is available and because drbd
kmod needs network to build, the build would fail.

This hack triggers a rebuild of the kmod at the first boot after
the system install/update safely.

Further updates will trigger the right builds at the right time

Signed-off-by: Fabio M. Di Nitto <fabbione@fabbione.net>