### PR TITLE
* Fixed a bug in anvil-daemon where, when an anvil-manage-power reboo…

### DIFF
--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -144,7 +144,7 @@ $anvil->data->{switches}{'no-start'}       = 0;
 $anvil->data->{switches}{'startup-only'}   = 0;
 $anvil->Get->switches;
 
-$anvil->Log->level({set => 1});
+$anvil->Log->level({set => 2});
 $anvil->Log->secure({set => 1});
 
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0115", variables => { program => $THIS_FILE }});
@@ -866,7 +866,7 @@ sub boot_time_tasks
 	
 	# If the uptime is less than ten minutes, clear the reboot flag.
 	my $uptime = $anvil->Get->uptime;
-	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { uptime => $uptime }});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { uptime => $uptime }});
 	
 	# Now find out if a reboot is listed as needed and when it was last changed.
 	my $reboot_needed       = 0;
@@ -921,7 +921,11 @@ AND
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { reboot_needed => $reboot_needed }});
 			
 			# Check to see if there was a reboot job in progress. If so, finish it off.
-			my $job_uuid = $anvil->Job->get_job_uuid({debug => 2, program => "anvil-manage-power"});
+			my $job_uuid = $anvil->Job->get_job_uuid({
+				debug      => 2, 
+				program    => "anvil-manage-power",
+				incomplete => 1,
+			});
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { job_uuid => $job_uuid }});
 			
 			if ($job_uuid)

--- a/tools/anvil-join-anvil
+++ b/tools/anvil-join-anvil
@@ -216,11 +216,14 @@ sub configure_pacemaker
 	($return_code) = $anvil->System->disable_daemon({daemon => "ksm.service"});
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { return_code => $return_code }});
 	$return_code = undef;
+	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, key => "job_0095", variables => { daemon => "ksm.service" }});
+	update_progress($anvil, ($anvil->data->{job}{progress} += 2), "job_0095,!!daemon!ksm.service!!");
+	
 	($return_code) = $anvil->System->stop_daemon({daemon => "ksmtuned.service"});
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { return_code => $return_code }});
 	$return_code = undef;
-	update_progress($anvil, ($anvil->data->{job}{progress} += 2), "job_0095,!!daemon!ksm.service!!");
-	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, key => "job_0095", variables => { daemon => "drbd.service" }});
+	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, key => "job_0095", variables => { daemon => "ksmtuned.service" }});
+	update_progress($anvil, ($anvil->data->{job}{progress} += 2), "job_0095,!!daemon!ksmtuned.service!!");
 	
 	# If there is no corosync.conf, see if the peer has it. If so, copy it. If not, we'll initialize the
 	# cluster shortly.

--- a/tools/anvil-manage-power
+++ b/tools/anvil-manage-power
@@ -215,7 +215,9 @@ sub do_poweroff
 		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => $say_task});
 		
 		sleep $difference;
-		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, secure => 0, key => "log_0227", variables => { task => $task eq "poweroff" ? "#!string!log_0225!#" : "#!string!log_0226!#" }});
+		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, secure => 0, key => "log_0227", variables => { 
+			task => $task eq "poweroff" ? "#!string!log_0225!#" : "#!string!log_0226!#",
+		}});
 	}
 	
 	# If I don't have a job_uuid, try to find one.


### PR DESCRIPTION
…t run had triggered a reboot, anvil-daemon didn't set the job_progress to '100', causing constant reboots. Also fixed a bug where the log level was hard-set to '1' instead of '2' needed during debugging.

* Updated Jobs->get_job_uuid() to accept the new 'incomplete' parameter that, when set, will look for jobs whose progress is > 1 and < 100.
* Updated ScanCore-agent_startup() to take the new 'no_db_ok' parameter which returns with '0' if no DB is available and that parameter is set to '1'.
* Fixed a logging bug in 'anvil-join-anvil'.

Signed-off-by: Digimer <digimer@alteeve.ca>