### PR TITLE
Web UI: add endpoint for getting server preview

### DIFF
--- a/Anvil/Tools.pm
+++ b/Anvil/Tools.pm
@@ -1106,6 +1106,7 @@ sub _set_paths
 				'anvil-delete-server'		=>	"/usr/sbin/anvil-delete-server",
 				'anvil-download-file'		=>	"/usr/sbin/anvil-download-file",
 				'anvil-file-details'		=>	"/usr/sbin/anvil-file-details",
+				'anvil-get-server-screenshot'	=>	"/usr/sbin/anvil-get-server-screenshot",
 				'anvil-join-anvil'		=>	"/usr/sbin/anvil-join-anvil",
 				'anvil-maintenance-mode'	=>	"/usr/sbin/anvil-maintenance-mode",
 				'anvil-manage-firewall'		=>	"/usr/sbin/anvil-manage-firewall",

--- a/anvil.spec.in
+++ b/anvil.spec.in
@@ -159,11 +159,11 @@ Requires:       libvirt-daemon-kvm
 Requires:       libvirt-docs 
 Requires:       pacemaker 
 Requires:       pcs 
+Requires:       python3-websockify
 Requires:       qemu-kvm 
 Requires:       qemu-kvm-core 
 Requires:       virt-install
 Requires:       virt-top
-Requires:       python3-websockify
 # A node is allowed to host servers and be a live migration target. It is not 
 # allowed to host a database or be a DR host.
 Conflicts:      anvil-striker
@@ -188,11 +188,11 @@ Requires:       libvirt-daemon
 Requires:       libvirt-daemon-driver-qemu 
 Requires:       libvirt-daemon-kvm 
 Requires:       libvirt-docs 
+Requires:       python3-websockify
 Requires:       qemu-kvm 
 Requires:       qemu-kvm-core 
 Requires:       virt-install
 Requires:       virt-top
-Requires:       python3-websockify
 # A DR host is not allowed to be a live-migration target or host a database.
 Conflicts:	anvil-striker
 Conflicts:	anvil-node

--- a/anvil.spec.in
+++ b/anvil.spec.in
@@ -157,6 +157,7 @@ Requires:       libvirt-daemon
 Requires:       libvirt-daemon-driver-qemu 
 Requires:       libvirt-daemon-kvm 
 Requires:       libvirt-docs 
+Requires:       netpbm-progs
 Requires:       pacemaker 
 Requires:       pcs 
 Requires:       python3-websockify
@@ -188,6 +189,7 @@ Requires:       libvirt-daemon
 Requires:       libvirt-daemon-driver-qemu 
 Requires:       libvirt-daemon-kvm 
 Requires:       libvirt-docs 
+Requires:       netpbm-progs
 Requires:       python3-websockify
 Requires:       qemu-kvm 
 Requires:       qemu-kvm-core 

--- a/cgi-bin/Makefile.am
+++ b/cgi-bin/Makefile.am
@@ -7,6 +7,7 @@ dist_cgibin_SCRIPTS     = \
                           get_memory \
                           get_networks \
                           get_replicated_storage \
+                          get_server_screenshot \
                           get_servers \
                           get_shared_storage \
                           get_status \

--- a/cgi-bin/get_server_screenshot
+++ b/cgi-bin/get_server_screenshot
@@ -1,0 +1,124 @@
+#!/usr/bin/perl
+#
+# Gets a server VM's screenshot and convert it to a Base64 string.
+#
+
+use strict;
+use warnings;
+use Anvil::Tools;
+use JSON;
+
+$| = 1;
+
+my $THIS_FILE           =  ($0 =~ /^.*\/(.*)$/)[0];
+my $running_directory   =  ($0 =~ /^(.*?)\/$THIS_FILE$/)[0];
+if (($running_directory =~ /^\./) && ($ENV{PWD}))
+{
+	$running_directory =~ s/^\./$ENV{PWD}/;
+}
+
+my $anvil = Anvil::Tools->new();
+
+sub is_job_incomplete
+{
+	my $parameters = shift;
+	my $job_uuid   = $parameters->{job_uuid};
+
+	my $query = "
+SELECT
+	job_progress
+FROM
+	public.jobs
+WHERE
+	job_uuid = ".$anvil->Database->quote($job_uuid)."
+;";
+
+	my $job_progress = $anvil->Database->query({ query => $query, source => $THIS_FILE, line => __LINE__ })->[0]->[0];
+
+	return $job_progress == 100 ? 0 : 1;
+}
+
+sub get_server_host_uuid
+{
+	my $parameters  = shift;
+	my $server_uuid = $parameters->{server_uuid};
+
+	my $query = "
+SELECT
+	server_host_uuid
+FROM
+	public.servers
+WHERE
+	server_uuid = ".$anvil->Database->quote($server_uuid)."
+;";
+
+	return $anvil->Database->query({ query => $query, source => $THIS_FILE, line => __LINE__ })->[0]->[0];
+}
+
+sub get_screenshot
+{
+	my $parameters       = shift;
+	my $server_uuid      = $parameters->{server_uuid};
+	my $server_host_uuid = $parameters->{server_host_uuid};
+
+	my ($job_uuid) = $anvil->Database->insert_or_update_jobs({
+		job_command     => $anvil->data->{path}{exe}{'anvil-get-server-screenshot'},
+		job_data        => "server-uuid=".$server_uuid,
+		job_host_uuid   => $server_host_uuid,
+		job_description => "job_0357",
+		job_name        => "cgi-bin::get_server_screenshot::".$server_uuid,
+		job_progress    => 0,
+		job_title       => "job_0356"
+	});
+
+	# Wait until the job is complete before continuing.
+	while(is_job_incomplete({ job_uuid => $job_uuid }))
+	{
+		sleep(2);
+	}
+
+	my ($encoded_image) = $anvil->Database->read_variable({ variable_name => "server_screenshot::".$server_uuid });
+
+	return $encoded_image;
+}
+
+$anvil->Get->switches;
+
+$anvil->Database->connect;
+$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
+if (not $anvil->data->{sys}{database}{connections})
+{
+	# No databases, exit.
+	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, priority => "err", key => "error_0003"});
+	$anvil->nice_exit({exit_code => 1});
+}
+
+my $cookie_problem = $anvil->Account->read_cookies();
+
+# Don't do anything data-related if the user is not logged in.
+if ($cookie_problem)
+{
+	$anvil->Log->entry({ source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, priority => "err", key => "error_0307" });
+	$anvil->nice_exit({ exit_code => 1 });
+}
+
+# Read in any CGI variables, if needed.
+$anvil->Get->cgi();
+
+print $anvil->Template->get({ file => "shared.html", name => "json_headers", show_name => 0 })."\n";
+
+my $server_uuid = defined $anvil->data->{cgi}{server_uuid}{value} ? $anvil->data->{cgi}{server_uuid}{value} : $anvil->data->{switches}{'server-uuid'};
+
+my $response_body = {};
+
+if ($server_uuid)
+{
+	my $encoded_image = get_screenshot({ server_uuid => $server_uuid, server_host_uuid => get_server_host_uuid({ server_uuid => $server_uuid }) });
+
+	if (defined $encoded_image)
+	{
+		$response_body->{image} = $encoded_image;
+	}
+}
+
+print JSON->new->utf8->encode($response_body)."\n";

--- a/cgi-bin/get_server_screenshot
+++ b/cgi-bin/get_server_screenshot
@@ -60,10 +60,11 @@ sub get_screenshot
 	my $parameters       = shift;
 	my $server_uuid      = $parameters->{server_uuid};
 	my $server_host_uuid = $parameters->{server_host_uuid};
+	my $resize_args      = defined $parameters->{resize_args} ? $parameters->{resize_args} : "512x512";
 
 	my ($job_uuid) = $anvil->Database->insert_or_update_jobs({
 		job_command     => $anvil->data->{path}{exe}{'anvil-get-server-screenshot'},
-		job_data        => "server-uuid=".$server_uuid,
+		job_data        => "server-uuid=".$server_uuid."\nresize=".$resize_args,
 		job_host_uuid   => $server_host_uuid,
 		job_description => "job_0357",
 		job_name        => "cgi-bin::get_server_screenshot::".$server_uuid,
@@ -108,12 +109,17 @@ $anvil->Get->cgi();
 print $anvil->Template->get({ file => "shared.html", name => "json_headers", show_name => 0 })."\n";
 
 my $server_uuid = defined $anvil->data->{cgi}{server_uuid}{value} ? $anvil->data->{cgi}{server_uuid}{value} : $anvil->data->{switches}{'server-uuid'};
+my $resize_args = defined $anvil->data->{cgi}{resize}{value}      ? $anvil->data->{cgi}{resize}{value}      : $anvil->data->{switches}{'resize'};
 
 my $response_body = {};
 
 if ($server_uuid)
 {
-	my $encoded_image = get_screenshot({ server_uuid => $server_uuid, server_host_uuid => get_server_host_uuid({ server_uuid => $server_uuid }) });
+	my $encoded_image = get_screenshot({
+		server_uuid      => $server_uuid,
+		server_host_uuid => get_server_host_uuid({ server_uuid => $server_uuid }),
+		resize_args      => $resize_args
+	});
 
 	if (defined $encoded_image)
 	{

--- a/cgi-bin/get_server_screenshot
+++ b/cgi-bin/get_server_screenshot
@@ -117,7 +117,7 @@ if ($server_uuid)
 
 	if (defined $encoded_image)
 	{
-		$response_body->{image} = $encoded_image;
+		$response_body->{screenshot} = $encoded_image;
 	}
 }
 

--- a/cgi-bin/get_server_screenshot
+++ b/cgi-bin/get_server_screenshot
@@ -78,7 +78,13 @@ sub get_screenshot
 		sleep(2);
 	}
 
-	my ($encoded_image) = $anvil->Database->read_variable({ variable_name => "server_screenshot::".$server_uuid });
+	my $query = "
+SELECT state_note
+FROM public.states
+WHERE state_name = ".$anvil->Database->quote("server_screenshot::".$server_uuid)."
+;";
+
+	my $encoded_image = $anvil->Database->query({ query => $query, source => $THIS_FILE, line => __LINE__ })->[0]->[0];
 
 	return $encoded_image;
 }

--- a/share/words.xml
+++ b/share/words.xml
@@ -2256,6 +2256,10 @@ Are you sure that you want to delete the server: [#!variable!server_name!#]? [Ty
 		<key name="message_0260">Finished [#!variable!operation!#] VNC pipe for server UUID [#!variable!server_uuid!#] from host UUID [#!variable!host_uuid!#].</key>
 		<key name="message_0261">Finished dropping VNC pipes table.</key>
 		<key name="message_0262">Finished managing VNC pipes; no operations happened because requirements not met.</key>
+		<key name="message_0263">Preparing to get server VM screenshot.</key>
+		<key name="message_0264">Finished getting server VM screenshot.</key>
+		<key name="message_0265">Failed to get server VM screenshot; got non-zero return code.</key>
+		<key name="message_0266">Finished attempting to get server VM screenshot; no operations happened because requirements not met.</key>
 		
 		<!-- Success messages shown to the user --> 
 		<key name="ok_0001">Saved the mail server information successfully!</key>

--- a/share/words.xml
+++ b/share/words.xml
@@ -1148,6 +1148,8 @@ It should be provisioned in the next minute or two.</key>
 		<key name="job_0353">* Please enter the name of the server you want to manage</key>
 		<key name="job_0354">-=] Servers available to manage on the Anvil! [#!variable!anvil_name!#] [=-</key>
 		<key name="job_0355">-=] Managing the server: [#!variable!server_name!#] on the Anvil!: [#!variable!anvil_name!#]</key>
+		<key name="job_0356">Get Server VM Screenshot</key>
+		<key name="job_0357">Fetch a screenshot of the specified server VM and represent it as a Base64 string.</key>
 		
 		<!-- Log entries -->
 		<key name="log_0001">Starting: [#!variable!program!#].</key>

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -14,6 +14,7 @@ dist_sbin_SCRIPTS	= \
 			  anvil-delete-server \
 			  anvil-download-file \
 			  anvil-file-details \
+			  anvil-get-server-screenshot \
 			  anvil-join-anvil \
 			  anvil-maintenance-mode \
 			  anvil-manage-files \

--- a/tools/anvil-get-server-screenshot
+++ b/tools/anvil-get-server-screenshot
@@ -50,7 +50,7 @@ sub get_server_screenshot
 	my $parameters  = shift;
 	my $server_uuid = $parameters->{server_uuid};
 
-	my $shell_call = "virsh screenshot --domain ".$server_uuid." --file /dev/stdout | sed 's/Screenshot.*//' | base64";
+	my $shell_call = "virsh screenshot --domain ".$server_uuid." --file /dev/stdout | sed 's/Screenshot.*//' | base64 --wrap 0";
 	my ($shell_output, $shell_return_code) = system_call({ shell_call => $shell_call });
 
 	return $shell_return_code == 0 ? $shell_output : undef;

--- a/tools/anvil-get-server-screenshot
+++ b/tools/anvil-get-server-screenshot
@@ -49,13 +49,14 @@ sub get_server_screenshot
 {
 	my $parameters  = shift;
 	my $server_uuid = $parameters->{server_uuid};
-	my $resize_args = $parameters->{resize_args};
+	my ($resize_x, $resize_y) = split(/x/ , $parameters->{resize_args});
 
 	my $shell_call = "virsh screenshot --domain ".$server_uuid." --file /dev/stdout | sed 's/Screenshot.*//'";
 
-	if (defined $resize_args)
+	if ($resize_x =~ /^\d+$/ && $resize_y =~ /^\d+$/)
 	{
-		$shell_call .= " | convert - -resize ".$resize_args." png:-";
+		$shell_call .= " | pamscale -quiet -xyfit ".$resize_x." ".$resize_y;
+		$shell_call .= " | pamtopng -quiet";
 	}
 
 	$shell_call .= " | base64 --wrap 0";

--- a/tools/anvil-get-server-screenshot
+++ b/tools/anvil-get-server-screenshot
@@ -72,9 +72,9 @@ sub insert_server_screenshot
 	my $server_uuid   = $parameters->{server_uuid};
 	my $encoded_image = $parameters->{encoded_image};
 
-	$anvil->Database->insert_or_update_variables({
-		variable_name  => "server_screenshot::".$server_uuid,
-		variable_value => $encoded_image
+	$anvil->Database->insert_or_update_states({
+		state_name => "server_screenshot::".$server_uuid,
+		state_note => $encoded_image
 	});
 }
 

--- a/tools/anvil-get-server-screenshot
+++ b/tools/anvil-get-server-screenshot
@@ -1,0 +1,88 @@
+#!/usr/bin/perl
+#
+#
+#
+
+use strict;
+use warnings;
+use Anvil::Tools;
+
+$| = 1;
+
+my $THIS_FILE           =  ($0 =~ /^.*\/(.*)$/)[0];
+my $running_directory   =  ($0 =~ /^(.*?)\/$THIS_FILE$/)[0];
+if (($running_directory =~ /^\./) && ($ENV{PWD}))
+{
+	$running_directory =~ s/^\./$ENV{PWD}/;
+}
+
+my $anvil = Anvil::Tools->new();
+
+$anvil->Get->switches;
+
+$anvil->Database->connect;
+$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
+if (not $anvil->data->{sys}{database}{connections})
+{
+	# No databases, exit.
+	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, priority => "err", key => "error_0003"});
+	$anvil->nice_exit({exit_code => 1});
+}
+
+sub system_call
+{
+	my $parameters = shift;
+	my $shell_call = $parameters->{shell_call};
+
+	my ($shell_output, $shell_return_code) = $anvil->System->call({ shell_call => $shell_call });
+	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+		shell_call        => $shell_call,
+		shell_output      => $shell_output,
+		shell_return_code => $shell_return_code
+	} });
+
+	return ($shell_output, $shell_return_code);
+}
+
+sub get_server_screenshot
+{
+	my $parameters  = shift;
+	my $server_uuid = $parameters->{server_uuid};
+
+	my $shell_call = "virsh screenshot --domain ".$server_uuid." --file /dev/stdout | sed 's/Screenshot.*//' | base64";
+	my ($shell_output, $shell_return_code) = system_call({ shell_call => $shell_call });
+
+	return $shell_return_code == 0 ? $shell_output : undef;
+}
+
+sub insert_server_screenshot
+{
+	my $parameters    = shift;
+	my $server_uuid   = $parameters->{server_uuid};
+	my $encoded_image = $parameters->{encoded_image};
+
+	$anvil->Database->insert_or_update_variables({
+		variable_name  => "server_screenshot::".$server_uuid,
+		variable_value => $encoded_image
+	});
+}
+
+my $server_uuid   = $anvil->data->{switches}{'server-uuid'};
+my $is_stdout     = $anvil->data->{switches}{'stdout'};
+
+if ($server_uuid)
+{
+	my $encoded_image = get_server_screenshot({ server_uuid => $server_uuid });
+
+	if ($is_stdout)
+	{
+		print($encoded_image);
+	}
+	else
+	{
+		insert_server_screenshot({
+			server_uuid   => $server_uuid,
+			encoded_image => $encoded_image
+		});
+	}
+}

--- a/tools/anvil-get-server-screenshot
+++ b/tools/anvil-get-server-screenshot
@@ -49,8 +49,17 @@ sub get_server_screenshot
 {
 	my $parameters  = shift;
 	my $server_uuid = $parameters->{server_uuid};
+	my $resize_args = $parameters->{resize_args};
 
-	my $shell_call = "virsh screenshot --domain ".$server_uuid." --file /dev/stdout | sed 's/Screenshot.*//' | base64 --wrap 0";
+	my $shell_call = "virsh screenshot --domain ".$server_uuid." --file /dev/stdout | sed 's/Screenshot.*//'";
+
+	if (defined $resize_args)
+	{
+		$shell_call .= " | convert - -resize ".$resize_args." png:-";
+	}
+
+	$shell_call .= " | base64 --wrap 0";
+
 	my ($shell_output, $shell_return_code) = system_call({ shell_call => $shell_call });
 
 	return $shell_return_code == 0 ? $shell_output : undef;
@@ -105,27 +114,28 @@ if ($anvil->data->{switches}{'job-uuid'})
 		if ($line =~ /server-uuid=(.*?)$/)
 		{
 			$anvil->data->{switches}{'server-uuid'} = $1;
-			$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
-				'switches::server-uuid' => $anvil->data->{switches}{'server-uuid'}
-			} });
+		}
+
+		if ($line =~ /resize=(.*?)$/)
+		{
+			$anvil->data->{switches}{'resize'} = $1;
 		}
 
 		if ($line =~ /stdout=(.*?)$/)
 		{
 			$anvil->data->{switches}{'stdout'} = $1;
-			$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
-				'switches::stdout' => $anvil->data->{switches}{'stdout'}
-			} });
 		}
 	}
 }
 
 my $server_uuid = $anvil->data->{switches}{'server-uuid'};
+my $resize_args = $anvil->data->{switches}{'resize'};
 my $is_stdout   = $anvil->data->{switches}{'stdout'};
 my $job_uuid    = $anvil->data->{switches}{'job-uuid'};
 
 $anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
 	server_uuid => $server_uuid,
+	resize_args => $resize_args,
 	is_stdout   => $is_stdout,
 	job_uuid    => $job_uuid
 } });
@@ -136,7 +146,7 @@ if ($server_uuid)
 
 	if ($is_stdout)
 	{
-		$encoded_image = get_server_screenshot({ server_uuid => $server_uuid });
+		$encoded_image = get_server_screenshot({ server_uuid => $server_uuid, resize_args => $resize_args });
 
 		if (defined $encoded_image)
 		{
@@ -151,7 +161,7 @@ if ($server_uuid)
 	}
 	elsif (is_existing_server_screenshot_outdated({ server_uuid => $server_uuid }))
 	{
-		$encoded_image = get_server_screenshot({ server_uuid => $server_uuid });
+		$encoded_image = get_server_screenshot({ server_uuid => $server_uuid, resize_args => $resize_args });
 
 		if (defined $encoded_image)
 		{

--- a/tools/anvil-get-server-screenshot
+++ b/tools/anvil-get-server-screenshot
@@ -33,6 +33,18 @@ sub system_call
 	return ($shell_output, $shell_return_code);
 }
 
+sub is_existing_server_screenshot_outdated
+{
+	my $parameters  = shift;
+	my $server_uuid = $parameters->{server_uuid};
+
+	my ($encoded_image, $variable_uuid, $variable_mtime) = $anvil->Database->read_variable({ variable_name => "server_screenshot::".$server_uuid });
+
+	my $time_difference = time - $variable_mtime;
+
+	return $time_difference > 120 ? 1 : 0;
+}
+
 sub get_server_screenshot
 {
 	my $parameters  = shift;
@@ -120,27 +132,41 @@ $anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, lis
 
 if ($server_uuid)
 {
-	my $encoded_image = get_server_screenshot({ server_uuid => $server_uuid });
+	my $encoded_image;
 
-	if (defined $encoded_image)
+	if ($is_stdout)
 	{
-		if ($is_stdout)
+		$encoded_image = get_server_screenshot({ server_uuid => $server_uuid });
+
+		if (defined $encoded_image)
 		{
 			print($encoded_image);
+
+			$anvil->Job->update_progress({ progress => 100, message => "message_0264" });
 		}
 		else
 		{
-			insert_server_screenshot({
-				server_uuid   => $server_uuid,
-				encoded_image => $encoded_image
-			});
+			$anvil->Job->update_progress({ progress => 100, message => "message_0265" });
 		}
+	}
+	elsif (is_existing_server_screenshot_outdated({ server_uuid => $server_uuid }))
+	{
+		$encoded_image = get_server_screenshot({ server_uuid => $server_uuid });
 
-		$anvil->Job->update_progress({ progress => 100, message => "message_0264" });
+		if (defined $encoded_image)
+		{
+			insert_server_screenshot({ server_uuid => $server_uuid, encoded_image => $encoded_image });
+
+			$anvil->Job->update_progress({ progress => 100, message => "message_0264" });
+		}
+		else
+		{
+			$anvil->Job->update_progress({ progress => 100, message => "message_0265" });
+		}
 	}
 	else
 	{
-		$anvil->Job->update_progress({ progress => 100, message => "message_0265" });
+		$anvil->Job->update_progress({ progress => 100, message => "message_0266" });
 	}
 }
 else

--- a/tools/anvil-get-server-screenshot
+++ b/tools/anvil-get-server-screenshot
@@ -18,17 +18,6 @@ if (($running_directory =~ /^\./) && ($ENV{PWD}))
 
 my $anvil = Anvil::Tools->new();
 
-$anvil->Get->switches;
-
-$anvil->Database->connect;
-$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
-if (not $anvil->data->{sys}{database}{connections})
-{
-	# No databases, exit.
-	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, priority => "err", key => "error_0003"});
-	$anvil->nice_exit({exit_code => 1});
-}
-
 sub system_call
 {
 	my $parameters = shift;
@@ -67,22 +56,94 @@ sub insert_server_screenshot
 	});
 }
 
-my $server_uuid   = $anvil->data->{switches}{'server-uuid'};
-my $is_stdout     = $anvil->data->{switches}{'stdout'};
+$anvil->Get->switches;
+
+$anvil->Database->connect;
+$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, secure => 0, key => "log_0132"});
+if (not $anvil->data->{sys}{database}{connections})
+{
+	# No databases, exit.
+	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, 'print' => 1, priority => "err", key => "error_0003"});
+	$anvil->nice_exit({exit_code => 1});
+}
+
+# Try to get a job UUID if not given.
+if (not $anvil->data->{switches}{'job-uuid'})
+{
+	$anvil->data->{switches}{'job-uuid'} = $anvil->Job->get_job_uuid({ program => $THIS_FILE });
+	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+		"switches::job-uuid" => $anvil->data->{switches}{'job-uuid'}
+	} });
+}
+
+# Handle this script as a job when job UUID is provided.
+if ($anvil->data->{switches}{'job-uuid'})
+{
+	$anvil->Job->clear();
+	$anvil->Job->get_job_details();
+	$anvil->Job->update_progress({
+		progress         => 1,
+		job_picked_up_by => $$,
+		job_picked_up_at => time,
+		message          => "message_0263"
+	});
+
+	foreach my $line (split/\n/, $anvil->data->{jobs}{job_data})
+	{
+		if ($line =~ /server-uuid=(.*?)$/)
+		{
+			$anvil->data->{switches}{'server-uuid'} = $1;
+			$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+				'switches::server-uuid' => $anvil->data->{switches}{'server-uuid'}
+			} });
+		}
+
+		if ($line =~ /stdout=(.*?)$/)
+		{
+			$anvil->data->{switches}{'stdout'} = $1;
+			$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+				'switches::stdout' => $anvil->data->{switches}{'stdout'}
+			} });
+		}
+	}
+}
+
+my $server_uuid = $anvil->data->{switches}{'server-uuid'};
+my $is_stdout   = $anvil->data->{switches}{'stdout'};
+my $job_uuid    = $anvil->data->{switches}{'job-uuid'};
+
+$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+	server_uuid => $server_uuid,
+	is_stdout   => $is_stdout,
+	job_uuid    => $job_uuid
+} });
 
 if ($server_uuid)
 {
 	my $encoded_image = get_server_screenshot({ server_uuid => $server_uuid });
 
-	if ($is_stdout)
+	if (defined $encoded_image)
 	{
-		print($encoded_image);
+		if ($is_stdout)
+		{
+			print($encoded_image);
+		}
+		else
+		{
+			insert_server_screenshot({
+				server_uuid   => $server_uuid,
+				encoded_image => $encoded_image
+			});
+		}
+
+		$anvil->Job->update_progress({ progress => 100, message => "message_0264" });
 	}
 	else
 	{
-		insert_server_screenshot({
-			server_uuid   => $server_uuid,
-			encoded_image => $encoded_image
-		});
+		$anvil->Job->update_progress({ progress => 100, message => "message_0265" });
 	}
+}
+else
+{
+	$anvil->Job->update_progress({ progress => 100, message => "message_0266" });
 }


### PR DESCRIPTION
The endpoint will trigger a job that calls the `tools/anvil-get-server-screenshot` script on the host which the server VM is running on. The output (Base64 string) will be stored in the `variables` table and picked up by the endpoint once it detects the job has completed.

An important note is the screenshot does not go through any type of compressions at the moment due to the lack of tools on RHEL (and probably CentOS), i.e., `imagemagick`.

Closes #172 