### PR TITLE
Reworked Database->_find_behind_databases to loop through tables, the…

### DIFF
--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -879,9 +879,6 @@ AND
 				$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0124", variables => { query => $query }});
 				$anvil->Database->write({debug => 2, query => $query, source => $THIS_FILE, line => __LINE__});
 			}
-			### TODO: What are the chances of a PID being reused in the minute between 
-			###       the program's death and us detecting it? Should we filter the 
-			###       'pids::<pid>::command' value against our programs and scan agents?
 		}
 	}
 	


### PR DESCRIPTION
…n databases when evaluating for resync. This is still racy but should be less racy as the time between counts of columns for a given table should be a lot shorter. Also re-enabled triggering resyncs based on the age of the most recent record.

Signed-off-by: Digimer <digimer@alteeve.ca>