### PR TITLE
* There is a fix in this commit to resolve a race condition where, wh…

### DIFF
--- a/Anvil/Tools.pm
+++ b/Anvil/Tools.pm
@@ -1168,6 +1168,7 @@ sub _set_paths
 				ifdown				=>	"/sbin/ifdown",
 				ifup				=>	"/sbin/ifup",
 				ip				=>	"/usr/sbin/ip",
+				iperf3				=>	"/usr/bin/iperf3", 
 				'ipmi-oem'			=>	"/usr/sbin/ipmi-oem",
 				ipmitool			=>	"/usr/bin/ipmitool",
 				### NOTE: When Network->manage_firewall() is done, search for and replace all
@@ -1176,6 +1177,7 @@ sub _set_paths
 				iptables			=>	"/usr/sbin/iptables",
 				'iptables-save'			=>	"/usr/sbin/iptables-save",
 				journalctl			=>	"/usr/bin/journalctl",
+				'kill'				=>	"/usr/bin/kill",
 				logger				=>	"/usr/bin/logger",
 				ls				=>	"/usr/bin/ls",
 				lsblk				=>	"/usr/bin/lsblk",
@@ -1203,6 +1205,7 @@ sub _set_paths
 				passwd				=>	"/usr/bin/passwd",
 				pcs				=>	"/usr/sbin/pcs",
 				perccli64			=>	"/opt/MegaRAID/perccli/perccli64",
+				pidof				=>	"/usr/sbin/pidof",
 				ping				=>	"/usr/bin/ping",
 				pg_dump				=>	"/usr/bin/pg_dump",
 				pgrep				=>	"/usr/bin/pgrep",

--- a/Anvil/Tools/Cluster.pm
+++ b/Anvil/Tools/Cluster.pm
@@ -561,7 +561,7 @@ B<< Note >>; The method relies on pacemaker to boot the node. As such, if for so
 
 =head3 wait (optional, default '1')
 
-This controls whether the method waits for the server to shut down before returning. By default, it will go into a loop and check every 2 seconds to see if the server is still running. Once it's found to be off, the method returns. If this is set to C<< 0 >>, the method will return as soon as the request to shut down the server is issued.
+This controls whether the method waits for the server to actually boot up before returning. By default, it will go into a loop and check every 2 seconds to see if the server is still running. Once it's found to be running, the method returns. If this is set to C<< 0 >>, the method will return as soon as the request to shut down the server is issued.
 
 =cut
 sub boot_server

--- a/Anvil/Tools/Convert.pm
+++ b/Anvil/Tools/Convert.pm
@@ -1365,7 +1365,7 @@ sub time
 	if ($time =~ /\D/)
 	{
 		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, priority => "err", key => "log_0294", variables => { 'time' => $time }});
-		return("#!error!#");
+		return($time);
 	}
 	
 	# The suffix used for each unit of time will depend on the requested suffix type.

--- a/Anvil/Tools/Database.pm
+++ b/Anvil/Tools/Database.pm
@@ -2707,8 +2707,11 @@ WHERE
 			next if not $anvil->data->{file_locations}{file_location_uuid}{$file_location_uuid}{file_location_active};
 			
 			my $file_uuid = $anvil->data->{file_locations}{file_location_uuid}{$file_location_uuid}{file_location_file_uuid};
+			
+			next if not exists $anvil->data->{files}{file_uuid}{$file_uuid};
+			
 			my $file_name = $anvil->data->{files}{file_uuid}{$file_uuid}{file_name};
-			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 				file_uuid => $file_uuid,
 				file_name => $file_name, 
 			}});
@@ -2720,7 +2723,7 @@ WHERE
 			$anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_size}      = $anvil->data->{files}{file_uuid}{$file_uuid}{file_size};
 			$anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_md5sum}    = $anvil->data->{files}{file_uuid}{$file_uuid}{file_md5sum};
 			$anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_type}      = $anvil->data->{files}{file_uuid}{$file_uuid}{file_type};
-			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 				"anvils::anvil_uuid::${anvil_uuid}::file_uuid::${file_uuid}::file_name"      => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_name}, 
 				"anvils::anvil_uuid::${anvil_uuid}::file_uuid::${file_uuid}::file_directory" => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_directory}, 
 				"anvils::anvil_uuid::${anvil_uuid}::file_uuid::${file_uuid}::file_size"      => $anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_size}})." (".$anvil->Convert->add_commas({number => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_uuid}{$file_uuid}{file_size}}).")", 
@@ -2730,7 +2733,7 @@ WHERE
 			
 			# Make it so that we can list the files by name.
 			$anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_name}{$file_name}{file_uuid} = $file_uuid;
-			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 				"anvils::anvil_uuid::${anvil_uuid}::file_name::${file_name}::file_uuid" => $anvil->data->{anvils}{anvil_uuid}{$anvil_uuid}{file_name}{$file_name}{file_uuid}, 
 			}});
 		}
@@ -17399,8 +17402,8 @@ sub _age_out_data
 	}
 	
 	# Now process power and tempoerature, if not disabled.
-	my $age = $anvil->data->{scancore}{database}{age_out};
-	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { age => $age }});
+	my $age = $anvil->data->{scancore}{database}{age_out} ? $anvil->data->{scancore}{database}{age_out} : 24; 
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { age => $age }});
 	
 	if ($age =~ /\D/)
 	{

--- a/Anvil/Tools/Database.pm
+++ b/Anvil/Tools/Database.pm
@@ -997,7 +997,7 @@ sub configure_pgsql
 		}
 	}
 	
-	# Do user and DB checks only if we're made a change above.
+	# Do user and DB checks only if we've made a change above.
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 		's1:initialized'            => $initialized,
 		's2:update_postgresql_file' => $update_postgresql_file, 
@@ -1362,7 +1362,7 @@ sub connect
 	# This method just returns if nothing is needed.
 	if (($local_host_type eq "striker") && ($check_if_configured) && ($< == 0) && ($> == 0))
 	{
-		$anvil->Database->configure_pgsql({debug => $debug, uuid => $local_host_uuid});
+		$anvil->Database->configure_pgsql({debug => 2, uuid => $local_host_uuid});
 	}
 	
 	# Now setup or however-many connections

--- a/Anvil/Tools/Log.pm
+++ b/Anvil/Tools/Log.pm
@@ -766,7 +766,7 @@ In this case, C<< $switches >> would contain C<< -vv --log-secure >>.
 
 B<< Note >>: The string returned is padded with a leading space so that this method can be called directly after the executable. Example;
 
- my $shell_call = $anvil->data->{path}{exe}{'striker-prep-database'}.$anvil->Log->switches();
+ my $shell_call = $anvil->data->{path}{exe}{'anvil-provision-server'}.$anvil->Log->switches();
 
 This method takes no parameters.
 

--- a/Anvil/Tools/Network.pm
+++ b/Anvil/Tools/Network.pm
@@ -2969,6 +2969,19 @@ sub manage_firewall
 		zone        => $zone
 	}});
 	
+	### TODO: Remove when fixed.
+	my $firewalld_running = $anvil->System->check_daemon({daemon => $anvil->data->{sys}{daemon}{firewalld}});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { firewalld_running => $firewalld_running }});
+	if ($firewalld_running)
+	{
+		# Disable and stop.
+		$anvil->System->disable_daemon({
+			now    => 1, 
+			daemon => $anvil->data->{sys}{daemon}{firewalld}.
+		});
+	}
+	
+	
 	return(0);
 	
 	# Before we do anything, is the firewall even running?

--- a/Anvil/Tools/Network.pm
+++ b/Anvil/Tools/Network.pm
@@ -1565,10 +1565,14 @@ sub get_ips
 	foreach my $line (split/\n/, $output)
 	{
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { line => $line }});
-		if ($line =~ /^\d+: (.*?): /)
+		if ($line =~ /^\d+: (.*?): <(.*?)>/)
 		{
 			$in_iface = $1;
-			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { in_iface => $in_iface }});
+			$stateus  = $2;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
+				in_iface => $in_iface,
+				status   => $status, 
+			}});
 			
 			$anvil->data->{network}{$host}{interface}{$in_iface}{ip}              = "" if not defined $anvil->data->{network}{$host}{interface}{$in_iface}{ip};
 			$anvil->data->{network}{$host}{interface}{$in_iface}{subnet_mask}     = "" if not defined $anvil->data->{network}{$host}{interface}{$in_iface}{subnet_mask};
@@ -1579,6 +1583,7 @@ sub get_ips
 			$anvil->data->{network}{$host}{interface}{$in_iface}{dns}             = "" if not defined $anvil->data->{network}{$host}{interface}{$in_iface}{dns};
 			$anvil->data->{network}{$host}{interface}{$in_iface}{tx_bytes}        = 0  if not defined $anvil->data->{network}{$host}{interface}{$in_iface}{tx_bytes};
 			$anvil->data->{network}{$host}{interface}{$in_iface}{rx_bytes}        = 0  if not defined $anvil->data->{network}{$host}{interface}{$in_iface}{rx_bytes};
+			$anvil->data->{network}{$host}{interface}{$in_iface}{status}          = $status
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 				"network::${host}::interface::${in_iface}::ip"              => $anvil->data->{network}{$host}{interface}{$in_iface}{ip}, 
 				"network::${host}::interface::${in_iface}::subnet_mask"     => $anvil->data->{network}{$host}{interface}{$in_iface}{subnet_mask}, 
@@ -1587,6 +1592,7 @@ sub get_ips
 				"network::${host}::interface::${in_iface}::default_gateway" => $anvil->data->{network}{$host}{interface}{$in_iface}{default_gateway}, 
 				"network::${host}::interface::${in_iface}::gateway"         => $anvil->data->{network}{$host}{interface}{$in_iface}{gateway}, 
 				"network::${host}::interface::${in_iface}::dns"             => $anvil->data->{network}{$host}{interface}{$in_iface}{dns}, 
+				"network::${host}::interface::${in_iface}::status"          => $anvil->data->{network}{$host}{interface}{$in_iface}{status}, 
 			}});
 			
 			if ($in_iface ne "lo")

--- a/Anvil/Tools/Network.pm
+++ b/Anvil/Tools/Network.pm
@@ -1567,8 +1567,8 @@ sub get_ips
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { line => $line }});
 		if ($line =~ /^\d+: (.*?): <(.*?)>/)
 		{
-			$in_iface = $1;
-			$stateus  = $2;
+			   $in_iface = $1;
+			my $status   = $2;
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 				in_iface => $in_iface,
 				status   => $status, 
@@ -1583,7 +1583,7 @@ sub get_ips
 			$anvil->data->{network}{$host}{interface}{$in_iface}{dns}             = "" if not defined $anvil->data->{network}{$host}{interface}{$in_iface}{dns};
 			$anvil->data->{network}{$host}{interface}{$in_iface}{tx_bytes}        = 0  if not defined $anvil->data->{network}{$host}{interface}{$in_iface}{tx_bytes};
 			$anvil->data->{network}{$host}{interface}{$in_iface}{rx_bytes}        = 0  if not defined $anvil->data->{network}{$host}{interface}{$in_iface}{rx_bytes};
-			$anvil->data->{network}{$host}{interface}{$in_iface}{status}          = $status
+			$anvil->data->{network}{$host}{interface}{$in_iface}{status}          = $status;
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 				"network::${host}::interface::${in_iface}::ip"              => $anvil->data->{network}{$host}{interface}{$in_iface}{ip}, 
 				"network::${host}::interface::${in_iface}::subnet_mask"     => $anvil->data->{network}{$host}{interface}{$in_iface}{subnet_mask}, 

--- a/Anvil/Tools/Network.pm
+++ b/Anvil/Tools/Network.pm
@@ -2977,21 +2977,20 @@ sub manage_firewall
 		# Disable and stop.
 		$anvil->System->disable_daemon({
 			now    => 1, 
-			daemon => $anvil->data->{sys}{daemon}{firewalld}.
+			daemon => $anvil->data->{sys}{daemon}{firewalld},
 		});
 	}
-	
 	
 	return(0);
 	
 	# Before we do anything, is the firewall even running?
-	my $firewalld_running = $anvil->Network->check_firewall({debug => $debug});
-	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { firewalld_running => $firewalld_running }});
-	if (not $firewalld_running)
-	{
-		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 2, key => "log_0669"});
-		return(1);
-	}
+# 	my $firewalld_running = $anvil->Network->check_firewall({debug => $debug});
+# 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { firewalld_running => $firewalld_running }});
+# 	if (not $firewalld_running)
+# 	{
+# 		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 2, key => "log_0669"});
+# 		return(1);
+# 	}
 	
 	# What we do next depends on what we're doing. 
 	my $host_type = $anvil->Get->host_type;

--- a/Anvil/Tools/Network.pm
+++ b/Anvil/Tools/Network.pm
@@ -254,6 +254,7 @@ sub check_firewall
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => $debug, key => "log_0125", variables => { method => "Network->check_firewall()" }});
 	
 	my $running = 0;
+	return(0);
 	
 	# Make sure firewalld is running.
 	my $firewalld_running = $anvil->System->check_daemon({daemon => $anvil->data->{sys}{daemon}{firewalld}});
@@ -2967,6 +2968,8 @@ sub manage_firewall
 		protocol    => $protocol, 
 		zone        => $zone
 	}});
+	
+	return(0);
 	
 	# Before we do anything, is the firewall even running?
 	my $firewalld_running = $anvil->Network->check_firewall({debug => $debug});

--- a/Anvil/Tools/System.pm
+++ b/Anvil/Tools/System.pm
@@ -5212,6 +5212,8 @@ sub _load_firewalld_zones
 	my $debug     = defined $parameter->{debug} ? $parameter->{debug} : 3;
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => $debug, key => "log_0125", variables => { method => "System->_load_firewalld_zones()" }});
 	
+	return(0);
+	
 	my $directory = $anvil->data->{path}{directories}{firewalld_services};
 	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => $debug, key => "log_0018", variables => { directory => $directory }});
 	if (not -d $directory)

--- a/Anvil/Tools/Validate.pm
+++ b/Anvil/Tools/Validate.pm
@@ -528,7 +528,7 @@ sub ip
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { ip => $ip }});
 	
 
-	my $ipv4 =                $anvil->Validate->ipv4({ip => $ip, debug => $debug});
+	my $ipv4 =             $anvil->Validate->ipv4({ip => $ip, debug => $debug});
 	my $ipv6 = not $ipv4 ? $anvil->Validate->ipv6({ip => $ip, debug => $debug}) : 0;
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 		ipv4 => $ipv4,

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -8,5 +8,6 @@ dist_man5_MANS		= \
 
 dist_man8_MANS		= \
 			  alteeve-repo-setup.8 \
+			  anvil-boot-server.8 \
 			  anvil-daemon.8 \
 			  scancore.8

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -9,5 +9,7 @@ dist_man5_MANS		= \
 dist_man8_MANS		= \
 			  alteeve-repo-setup.8 \
 			  anvil-boot-server.8 \
+			  anvil-check-memory.8 \
+			  anvil-configure-host.8 \
 			  anvil-daemon.8 \
 			  scancore.8

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -7,4 +7,6 @@ dist_man5_MANS		= \
 			  anvil.conf.5
 
 dist_man8_MANS		= \
-			  anvil-daemon.8
+			  alteeve-repo-setup.8 \
+			  anvil-daemon.8 \
+			  scancore.8

--- a/man/alteeve-repo-setup.8
+++ b/man/alteeve-repo-setup.8
@@ -1,0 +1,52 @@
+.\" Manpage for the Alteeve! repo setup tool
+.\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
+.TH alteeve-repo-setup "8" "August 02 2022" "Anvil! Intelligent Availability™ Platform"
+.SH NAME
+alteeve-repo-setup \- Tool used to configure the Anvil! repository.
+.SH SYNOPSIS
+.B alteeve-repo-setup 
+\fI\,<command> \/\fR[\fI\,options\/\fR]
+.SH DESCRIPTION
+alteeve-repo-setup \- This tool configures the local repository needed to install the Anvil! Intelligent Availability™ platform. The repository will be based on the OS running on this system. For example, if the host is RHEL 8, the repo will be configured for 'rhel-8'. Similarly, if this host is CentOS 8 Stream, the repo will be configured for 'centos-8-stream'. 
+.TP
+There are two main repos for the Anvil! system; 
+.TP
+- community:  This repo is free for use, and tracks the latest available release of the Anvil! platform.
+.TP
+For support on the Community version is provided through;
+.TP
+* Alteeve Wiki      - https://wiki.alteeve.com/
+.TP
+* Alteeve Support   - https://www.alteeve.com/c/supportandresources/contact-support/
+.TP
+* ClusterLabs Users - https://lists.clusterlabs.org/mailman/listinfo/users
+.TP
+* ClusterLabs on Libera Chat's #clusterlabs channel
+.TP
+- enterprise: This repo has additional testing and hardening, but is slower to get new features. 
+.TP
+To access our enterprise repository with Alteeve support please visit: 
+.TP
+* https://www.alteeve.com/c/supportandresources/contact-support/
+.SH OPTIONS
+.TP
+\-?, \-h, \fB\-\-help\fR
+Show this man page.
+.TP
+\fB\-\-log-secure\fR
+When logging, record sensitive data, like passwords.
+.TP
+\-d, \fB\-\-debug\fR
+This tool does not use the main Anvil::Tools modules, so debugging is limited to messaged shown during the run. This enables those debug messages.
+.SS "Commands:"
+.TP
+\-k, \fB\-\---key\fR <uuid>
+If you have a key, provide it this way. This will configure the host to use the enterprise repository.
+.TP
+\-y, \fB\-\-yes\fR
+Do not ask to confirm the use of the community repository.
+.IP
+.SH AUTHOR
+Written by Madison Kelly, Alteeve staff and the Anvil! project contributors.
+.SH "REPORTING BUGS"
+Report bugs to users@clusterlabs.org

--- a/man/alteeve-repo-setup.8
+++ b/man/alteeve-repo-setup.8
@@ -40,7 +40,7 @@ When logging, record sensitive data, like passwords.
 This tool does not use the main Anvil::Tools modules, so debugging is limited to messaged shown during the run. This enables those debug messages.
 .SS "Commands:"
 .TP
-\-k, \fB\-\---key\fR <uuid>
+\-k, \fB\-\-key\fR <uuid>
 If you have a key, provide it this way. This will configure the host to use the enterprise repository.
 .TP
 \-y, \fB\-\-yes\fR

--- a/man/anvil-boot-server.8
+++ b/man/anvil-boot-server.8
@@ -1,0 +1,48 @@
+.\" Manpage for the Anvil! server boot program
+.\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
+.TH anvil-boot-server "8" "August 02 2022" "Anvil! Intelligent Availability™ Platform"
+.SH NAME
+anvil-boot-server \- Tool used to boot servers (virtual machines) on the Anvil! IA cluster.
+.SH SYNOPSIS
+.B alteeve-repo-setup 
+\fI\,<command> \/\fR[\fI\,options\/\fR]
+.SH DESCRIPTION
+anvil-boot-server \- This tool allows booting of hosted servers on an Anvil! cluster, or a specific sub-node if desired.
+.TP
+This method, when used with '\fB\-\-server\fR all', will honour server boot priority and delays.
+.TP
+.SH OPTIONS
+.TP
+\-?, \-h, \fB\-\-help\fR
+Show this man page.
+.TP
+\fB\-\-log-secure\fR
+When logging, record sensitive data, like passwords.
+.TP
+\-d, \fB\-\-debug\fR
+This tool does not use the main Anvil::Tools modules, so debugging is limited to messaged shown during the run. This enables those debug messages.
+.SS "Commands:"
+.TP
+\fB\-\-job-uuid\fR <uuid>
+This is set to the job UUID when the request to boot is coming from a database job. When set, the referenced job will be updated and marked as complete / failed when the run completes.
+.TP
+\fB\-\-no-wait\fR
+This controls whether the request to boot the server waits for the server to actually boot up before returning. Normally, the program will check every couple of seconds to see if the server has actually booted before returning. Setting this tells the program to return as soon as the request to boot the server has been passed on to the resource manager.
+.TP
+\fB\-\-server\fR <all|name|uuid>
+This is either 'all', the name, or server UUID (as set in the definition XML) of the server to boot. 
+.TP
+When set to 'all', all servers assigned to the local sub-cluster are booted. Servers on other Anvil! nodes are not started. 
+.TP
+\fB\-\-server-uuid\fR <uuid>
+This is the server UUID of the server to boot. Generally this isn't needed, except when two servers somehow share the same name. This should not be possible, but this option exists in case it happens anyway.
+.TP
+\fB\-\-wait\fR
+When using '\fB\-\-server\fR all', the request to boot each server will normally not wait for the server to boot. When this is set, this behaviour is changed and the boot will wait before moving on to boot the next server.
+.TP
+Be away that when this is used, if a server fails to boot, no further servers will be started.
+.IP
+.SH AUTHOR
+Written by Madison Kelly, Alteeve staff and the Anvil! project contributors.
+.SH "REPORTING BUGS"
+Report bugs to users@clusterlabs.org

--- a/man/anvil-boot-server.8
+++ b/man/anvil-boot-server.8
@@ -19,8 +19,8 @@ Show this man page.
 \fB\-\-log-secure\fR
 When logging, record sensitive data, like passwords.
 .TP
-\-d, \fB\-\-debug\fR
-This tool does not use the main Anvil::Tools modules, so debugging is limited to messaged shown during the run. This enables those debug messages.
+\-v, \-vv, \-vvv
+Set the log level to 1, 2 or 3 respectively. Be aware that level 3 generates a significant amount of log data.
 .SS "Commands:"
 .TP
 \fB\-\-job-uuid\fR <uuid>

--- a/man/anvil-boot-server.8
+++ b/man/anvil-boot-server.8
@@ -4,10 +4,10 @@
 .SH NAME
 anvil-boot-server \- Tool used to boot servers (virtual machines) on the Anvil! IA cluster.
 .SH SYNOPSIS
-.B alteeve-repo-setup 
+.B anvil-boot-server 
 \fI\,<command> \/\fR[\fI\,options\/\fR]
 .SH DESCRIPTION
-anvil-boot-server \- This tool allows booting of hosted servers on an Anvil! cluster, or a specific sub-node if desired.
+This tool allows booting of hosted servers on an Anvil! cluster, or a specific sub-node if desired.
 .TP
 This method, when used with '\fB\-\-server\fR all', will honour server boot priority and delays.
 .TP

--- a/man/anvil-change-password.8
+++ b/man/anvil-change-password.8
@@ -1,0 +1,42 @@
+.\" Manpage for the Anvil! server boot program
+.\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
+.TH anvil-change-password "8" "August 02 2022" "Anvil! Intelligent Availability™ Platform"
+.SH NAME
+anvil-change-password \- Tool used to change / reset the main Anvil! password.
+.SH SYNOPSIS
+.B alteeve-repo-setup 
+\fI\,<command> \/\fR[\fI\,options\/\fR]
+.SH DESCRIPTION
+anvil-change-password \- This is used to change / reset the password on a Striker dashboard. Alternatively, if '--anvil' is used, to change / reset the password on an Anvil! node pair.
+.TP
+Note: This password is used for the shell users, for the postgresql user and, when setting an Anvil! password, for the IPMI BMC user. In the later case, passwords over 16 characters will be truncated. Allowed characters are set by the limits on normal shell passwords.
+.TP
+.SH OPTIONS
+.TP
+\-?, \-h, \fB\-\-help\fR
+Show this man page.
+.TP
+\fB\-\-log-secure\fR
+When logging, record sensitive data, like passwords.
+.TP
+\-v, \-vv, \-vvv
+Set the log level to 1, 2 or 3 respectively. Be aware that level 3 generates a significant amount of log data.
+.SS "Commands:"
+.TP
+\fB\-\-anvil\fR <name|uuid>
+When set, this changes the password on the target Anvil! sub-cluster. This is the Anvil! sub-cluster name (ie: 'an-anvil-01') or the Anvil! UUID. 
+.TP
+When not set, the Striker dashboard this command is run on will have it's passwords updated.
+.TP
+\fB\-\-new-password\fR <secret>
+This is the new password to set. See '\fB\-\-password-file\fR' below for an alternate way to pass in the password. 
+.TP
+If not set, you will be prompted to enter the new password.
+.TP
+\fB\-\-password-file\fR </path/to/file>
+This is an alternative way to pass the new password to this program. If set, the file is read in and the file contents are used. Be sure to use one line only in the file.
+.IP
+.SH AUTHOR
+Written by Madison Kelly, Alteeve staff and the Anvil! project contributors.
+.SH "REPORTING BUGS"
+Report bugs to users@clusterlabs.org

--- a/man/anvil-check-memory.8
+++ b/man/anvil-check-memory.8
@@ -1,0 +1,34 @@
+.\" Manpage for the Anvil! server boot program
+.\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
+.TH anvil-check-memory "8" "August 02 2022" "Anvil! Intelligent Availability™ Platform"
+.SH NAME
+anvil-check-memory \- This reports the total memory used by all processes with to passed-in program name.
+.SH SYNOPSIS
+.B alteeve-repo-setup 
+\fI\,<command> \/\fR[\fI\,options\/\fR]
+.SH DESCRIPTION
+anvil-check-memory \-  This reports the total memory used by all processes with to passed-in program name. It can be an Anvil! or Striker program, or any other program running on the system.
+.TP
+This looks in 'ps' and finds pids for the given program name, then parses the '/proc/<pid>/smaps' kernel file to calculate the memory use. This will include shared memory space! Ending the program won't necessarily release the reported amount of RAM.
+.TP
+The output will be in the format: '<program_name> = <number_of_bytes> # <size in human readable format>
+.TP
+.SH OPTIONS
+.TP
+\-?, \-h, \fB\-\-help\fR
+Show this man page.
+.TP
+\fB\-\-log-secure\fR
+When logging, record sensitive data, like passwords.
+.TP
+\-v, \-vv, \-vvv
+Set the log level to 1, 2 or 3 respectively. Be aware that level 3 generates a significant amount of log data.
+.SS "Commands:"
+.TP
+\fB\-\-program\fR <name>
+This is the name of the program to report memory usage of. 
+.IP
+.SH AUTHOR
+Written by Madison Kelly, Alteeve staff and the Anvil! project contributors.
+.SH "REPORTING BUGS"
+Report bugs to users@clusterlabs.org

--- a/man/anvil-check-memory.8
+++ b/man/anvil-check-memory.8
@@ -1,4 +1,4 @@
-.\" Manpage for the Anvil! server boot program
+.\" Manpage for the Anvil! memory checking tool
 .\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
 .TH anvil-check-memory "8" "August 02 2022" "Anvil! Intelligent Availability™ Platform"
 .SH NAME

--- a/man/anvil-configure-host.8
+++ b/man/anvil-configure-host.8
@@ -2,16 +2,12 @@
 .\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
 .TH anvil-check-memory "8" "August 02 2022" "Anvil! Intelligent Availability™ Platform"
 .SH NAME
-anvil-check-memory \- This reports the total memory used by all processes with to passed-in program name.
+anvil-check-memory \- This program configures the host for use in an Anvil! cluster.
 .SH SYNOPSIS
 .B anvil-check-memory 
 \fI\,<command> \/\fR[\fI\,options\/\fR]
 .SH DESCRIPTION
-This reports the total memory used by all processes with to passed-in program name. It can be an Anvil! or Striker program, or any other program running on the system.
-.TP
-This looks in 'ps' and finds pids for the given program name, then parses the '/proc/<pid>/smaps' kernel file to calculate the memory use. This will include shared memory space! Ending the program won't necessarily release the reported amount of RAM.
-.TP
-The output will be in the format: '<program_name> = <number_of_bytes> # <size in human readable format>
+This picks up a job from the database and, using the data from it, configures the host to prepare it for use in an Anvil! cluster.
 .TP
 .SH OPTIONS
 .TP
@@ -25,8 +21,8 @@ When logging, record sensitive data, like passwords.
 Set the log level to 1, 2 or 3 respectively. Be aware that level 3 generates a significant amount of log data.
 .SS "Commands:"
 .TP
-\fB\-\-program\fR <name>
-This is the name of the program to report memory usage of. 
+\fB\-\-job-uuid\fR <name>
+The program is normally run as a job, with data on how to configure the host defined in the job. This switch allows the running of a specific job. If this is not set, the program will search for a job that has not yet been picked up by another process. If found, that job UUID is used automatically.
 .IP
 .SH AUTHOR
 Written by Madison Kelly, Alteeve staff and the Anvil! project contributors.

--- a/man/anvil-daemon.8
+++ b/man/anvil-daemon.8
@@ -21,7 +21,7 @@ Set the log level to 1, 2 or 3 respectively. Be aware that level 3 generates a s
 .SS "Commands:"
 .TP
 \fB\-\-refresh-json\fR (derecated)
-Short hand for '--run-once', '--main-loop-only' and '--no-start'. Used to be use to refresh the JSON file used by striker's web interface to know hardware states. 
+Short hand for '\fB\-\-run-once\fR', '\fB\-\-main-loop-only\fR' and '\fB\-\-no-start\fR'. Used to be use to refresh the JSON file used by striker's web interface to know hardware states. 
 .TP
 \fB\-\-main-loop-only\fR
 This skips the one-time, start-up tasks and just goes into the main-loop.

--- a/man/anvil-daemon.8
+++ b/man/anvil-daemon.8
@@ -1,8 +1,24 @@
-.TH anvil-daemon
+.\" Manpage for the Anvil! daemon. 
+.\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
+.TH anvil-daemon "8" "July 29 2022" "Anvil! Intelligent Availability™ Platform"
 .SH NAME
-anvil-daemon - Main systemd daemon for the Anvil! IA platform. Provides all job management, monitoring and Striker back-end functions.
+anvil-daemon \- Main systemd daemon for the M3 Anvil! IA cluster. Provides all job management, monitoring and Striker back-end functions. 
 .SH SYNOPSIS
-.B anvil-daemon
+.B anvil-daemon 
+\fI\,<command> \/\fR[\fI\,options\/\fR]
 .SH DESCRIPTION
-.B anvil-daemon
-Main daemon for the M3 Anvil! Intelligent Availability\*(Tm platform. Usually managed via 
+anvil-daemon \- Main systemd daemon that can be run manually for testing and debug reasons. No switches needed for normal operation by systemd.
+.SH OPTIONS
+.TP
+\-?, \-h, \fB\-\-help\fR
+Show a prompt to read this man page.
+.TP
+\fB\-\-refresh-json\fR (derecated)
+Short hand for '--run-once', '--main-loop-only' and '--no-start'. Used to be use to refresh the JSON file used by striker's web interface to know hardware states. 
+\fB\-\-refresh-json\fR (derecated)
+Short hand for '--run-once', '--main-loop-only' and '--no-start'. Used to be use to refresh the JSON file used by striker's web interface to know hardware states. 
+
+.SH AUTHOR
+Written by Madison Kelly, Alteeve staff and the Anvil! project contributors.
+.SH "REPORTING BUGS"
+Report bugs to users@clusterlabs.org

--- a/man/anvil-daemon.8
+++ b/man/anvil-daemon.8
@@ -11,13 +11,30 @@ anvil-daemon \- Main systemd daemon that can be run manually for testing and deb
 .SH OPTIONS
 .TP
 \-?, \-h, \fB\-\-help\fR
-Show a prompt to read this man page.
+Show this man page.
+.TP
+\fB\-\-log-secure\fR
+When logging, record sensitive data, like passwords.
+.TP
+\-v, \-vv, \-vvv
+Set the log level to 1, 2 or 3 respectively. Be aware that level 3 generates a significant amount of log data.
+.SS "Commands:"
 .TP
 \fB\-\-refresh-json\fR (derecated)
 Short hand for '--run-once', '--main-loop-only' and '--no-start'. Used to be use to refresh the JSON file used by striker's web interface to know hardware states. 
-\fB\-\-refresh-json\fR (derecated)
-Short hand for '--run-once', '--main-loop-only' and '--no-start'. Used to be use to refresh the JSON file used by striker's web interface to know hardware states. 
-
+.TP
+\fB\-\-main-loop-only\fR
+This skips the one-time, start-up tasks and just goes into the main-loop.
+.TP
+\fB\-\-no-start\fR
+This will prevent any pending jobs from being picked up and started in this run. Note that other job checks will still happen.
+.TP
+\fB\-\-run-once\fR
+This will tell the program to exit after runn the main loop once.
+.TP
+\fB\-\-startup-only\fR
+This will tell the program to exit after running the start up tasks, so the main loop won't run.
+.IP
 .SH AUTHOR
 Written by Madison Kelly, Alteeve staff and the Anvil! project contributors.
 .SH "REPORTING BUGS"

--- a/man/anvil-daemon.8
+++ b/man/anvil-daemon.8
@@ -30,7 +30,7 @@ This skips the one-time, start-up tasks and just goes into the main-loop.
 This will prevent any pending jobs from being picked up and started in this run. Note that other job checks will still happen.
 .TP
 \fB\-\-run-once\fR
-This will tell the program to exit after runn the main loop once.
+This will tell the program to exit after running the main loop once.
 .TP
 \fB\-\-startup-only\fR
 This will tell the program to exit after running the start up tasks, so the main loop won't run.

--- a/man/anvil-delete-server.8
+++ b/man/anvil-delete-server.8
@@ -1,13 +1,15 @@
-.\" Manpage for the Anvil! host configuration program
+.\" Manpage for the Anvil! server removal tool
 .\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
-.TH anvil-check-memory "8" "August 02 2022" "Anvil! Intelligent Availability™ Platform"
+.TH anvil-delete-server "8" "August 02 2022" "Anvil! Intelligent Availability™ Platform"
 .SH NAME
-anvil-check-memory \- This program configures the host for use in an Anvil! cluster.
+anvil-delete-server \- This program deletes a server from an Anvil! sub-cluster.
 .SH SYNOPSIS
-.B anvil-check-memory 
+.B anvil-delete-server 
 \fI\,<command> \/\fR[\fI\,options\/\fR]
 .SH DESCRIPTION
-This picks up a job from the database and, using the data from it, configures the host to prepare it for use in an Anvil! cluster.
+This deletes a server, running or stopped, from an Anvil! subcluster. The resource allocated to this server are removed and returned to the resource pool as well.
+.TP
+This action is permanent!
 .TP
 .SH OPTIONS
 .TP

--- a/man/scancore.8
+++ b/man/scancore.8
@@ -1,0 +1,32 @@
+.\" Manpage for the ScanCore daemon. 
+.\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
+.TH scancore "8" "July 29 2022" "Anvil! Intelligent Availability™ Platform"
+.SH NAME
+scancore \- ScanCore systemd daemon for the M3 Anvil! Cluster.
+.SH SYNOPSIS
+.B scancore 
+\fI\,<command> \/\fR[\fI\,options\/\fR]
+.SH DESCRIPTION
+scancore \- ScanCore provides all of the decision engine logic that provides all of the autonomous operation logic. How exactly it behaves depends on whether it is running on a Striker dashboard, Anvil! sub-node or DR host.
+.SH OPTIONS
+.TP
+\-?, \-h, \fB\-\-help\fR
+Show this man page.
+.TP
+\fB\-\-log-secure\fR
+When logging, record sensitive data, like passwords.
+.TP
+\-v, \-vv, \-vvv
+Set the log level to 1, 2 or 3 respectively. Be aware that level 3 generates a significant amount of log data.
+.SS "Commands:"
+.TP
+\fB\-\-purge\fR
+If passed, all scancore agents will be invoked with '\fB\-\-purge\fR'. This will cause all ScanCore data to be purged from the databases.
+.TP
+\fB\-\-run-once\fR
+This will tell the program to exit after one run of all scan agents and after doing to post-scan logic.
+.IP
+.SH AUTHOR
+Written by Madison Kelly, Alteeve staff and the Anvil! project contributors.
+.SH "REPORTING BUGS"
+Report bugs to users@clusterlabs.org

--- a/notes
+++ b/notes
@@ -6,6 +6,9 @@ dnf -y update && dnf -y install https://www.alteeve.com/an-repo/m3/anvil-release
 dnf -y update && dnf -y install https://www.alteeve.com/an-repo/m3/anvil-release-latest.noarch.rpm && alteeve-repo-setup -y && dnf -y install anvil-node --allowerasing
 dnf -y update && dnf -y install https://www.alteeve.com/an-repo/m3/anvil-release-latest.noarch.rpm && alteeve-repo-setup -y && dnf -y install anvil-dr --allowerasing
 
+### Get OUI out of the fucking database.
+
+
 
 ### Currently set default zone;
 # Doesn't seem to matter - /etc/firewalld/firewalld.conf:6:DefaultZone=public

--- a/notes
+++ b/notes
@@ -25,6 +25,7 @@ firewall-cmd --permanent --zone=IFN1 --add-port=22869/tcp
 firewall-cmd --reload
 
 
+
 # Configure APC PDUs and UPSes
 tcpip -i 10.201.2.3 -s 255.255.0.0 -g 10.201.255.254
 web -h enable

--- a/scancore-agents/Makefile.am
+++ b/scancore-agents/Makefile.am
@@ -70,6 +70,8 @@ networkdir			= ${targetdir}/scan-network
 dist_network_DATA		= \
 				  scan-network/scan-network.sql \
 				  scan-network/scan-network.xml
+dist_network_SCRIPTS            = \
+                                  scan-network
 
 serverdir			= ${targetdir}/scan-server
 dist_server_DATA		= \
@@ -84,3 +86,5 @@ dist_storcli_DATA		= \
 				  scan-storcli/scan-storcli.xml
 dist_storcli_SCRIPTS		= \
 				  scan-storcli/scan-storcli
+
+

--- a/scancore-agents/Makefile.am
+++ b/scancore-agents/Makefile.am
@@ -70,8 +70,8 @@ networkdir			= ${targetdir}/scan-network
 dist_network_DATA		= \
 				  scan-network/scan-network.sql \
 				  scan-network/scan-network.xml
-dist_network_SCRIPTS            = \
-                                  scan-network
+dist_network_SCRIPTS		= \
+                                  scan-network/scan-network
 
 serverdir			= ${targetdir}/scan-server
 dist_server_DATA		= \

--- a/scancore-agents/scan-apc-ups/scan-apc-ups
+++ b/scancore-agents/scan-apc-ups/scan-apc-ups
@@ -937,6 +937,7 @@ WHERE
 					low_transfer_voltage  => $low_transfer_voltage,
 					clear_low_transfer    => $clear_low_transfer, 
 				};
+				#	holdup_time           => $anvil->Convert->time({'time' => $scan_apc_ups_output_estimated_runtime}),
 				
 				my $lost_voltage_key = $scan_apc_ups_uuid."::scan_apc_ups_input_voltage_lost";
 				my $low_voltage_key  = $scan_apc_ups_uuid."::scan_apc_ups_input_voltage_low";

--- a/scancore-agents/scan-apc-ups/scan-apc-ups.xml
+++ b/scancore-agents/scan-apc-ups/scan-apc-ups.xml
@@ -162,7 +162,9 @@ Warning: If the UPS battery is the only high temperature, it could be a sign tha
 		<key name="scan_apc_ups_warning_0024">The input voltage for the UPS: [#!variable!ups_name!#] has risen from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>
 		<key name="scan_apc_ups_warning_0025">The input voltage for the UPS: [#!variable!ups_name!#] has dropped from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>
 		<key name="scan_apc_ups_warning_0026">The UPS: [#!variable!ups_name!#] has lost input power! The input voltage dropped from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>
-		<key name="scan_apc_ups_warning_0027">The input voltage for the UPS: [#!variable!ups_name!#] has dropped below the low-voltage transfer level! The voltage dropped from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC]. The low-voltage transfer voltage is: [#!variable!low_transfer_voltage!#].</key>
+		<key name="scan_apc_ups_warning_0027">
+The input voltage for the UPS: [#!variable!ups_name!#] has dropped below the low-voltage transfer level! The voltage dropped from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC]. The low-voltage transfer voltage is: [#!variable!low_transfer_voltage!#].
+</key>
 		<key name="scan_apc_ups_warning_0028">The input voltage for the UPS: [#!variable!ups_name!#] has dropped back down below the high-voltage transfer level and is operating normally again. The voltage changed from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC]. The clear high-voltage threshold is: [#!variable!clear_high_transfer!#].</key>
 		<key name="scan_apc_ups_warning_0029">The highest input voltage seen in the last 60 seconds for the UPS: [#!variable!ups_name!#] has changed from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>
 		<key name="scan_apc_ups_warning_0030">The lowest input voltage seen in the last 60 seconds for the UPS: [#!variable!ups_name!#] has changed from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>

--- a/scancore-agents/scan-apc-ups/scan-apc-ups.xml
+++ b/scancore-agents/scan-apc-ups/scan-apc-ups.xml
@@ -162,9 +162,7 @@ Warning: If the UPS battery is the only high temperature, it could be a sign tha
 		<key name="scan_apc_ups_warning_0024">The input voltage for the UPS: [#!variable!ups_name!#] has risen from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>
 		<key name="scan_apc_ups_warning_0025">The input voltage for the UPS: [#!variable!ups_name!#] has dropped from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>
 		<key name="scan_apc_ups_warning_0026">The UPS: [#!variable!ups_name!#] has lost input power! The input voltage dropped from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>
-		<key name="scan_apc_ups_warning_0027">
-The input voltage for the UPS: [#!variable!ups_name!#] has dropped below the low-voltage transfer level! The voltage dropped from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC]. The low-voltage transfer voltage is: [#!variable!low_transfer_voltage!#].
-</key>
+		<key name="scan_apc_ups_warning_0027">The input voltage for the UPS: [#!variable!ups_name!#] has dropped below the low-voltage transfer level! The voltage dropped from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC]. The low-voltage transfer voltage is: [#!variable!low_transfer_voltage!#].</key>
 		<key name="scan_apc_ups_warning_0028">The input voltage for the UPS: [#!variable!ups_name!#] has dropped back down below the high-voltage transfer level and is operating normally again. The voltage changed from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC]. The clear high-voltage threshold is: [#!variable!clear_high_transfer!#].</key>
 		<key name="scan_apc_ups_warning_0029">The highest input voltage seen in the last 60 seconds for the UPS: [#!variable!ups_name!#] has changed from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>
 		<key name="scan_apc_ups_warning_0030">The lowest input voltage seen in the last 60 seconds for the UPS: [#!variable!ups_name!#] has changed from: [#!variable!old_value!# vAC] to: [#!variable!new_value!# vAC].</key>

--- a/scancore-agents/scan-drbd/scan-drbd.xml
+++ b/scancore-agents/scan-drbd/scan-drbd.xml
@@ -233,6 +233,8 @@ The global common configuration file: [#!variable!file!#] needs to be updated. T
 		<key name="scan_drbd_state_attaching_explain">Transient state while reading meta data.</key>
 		<key name="scan_drbd_state_detaching_name">Detaching</key>
 		<key name="scan_drbd_state_detaching_explain">Transient state while detaching and waiting for ongoing IOs to complete.</key>
+		<key name="scan_drbd_state_DELETED_name">Deleted</key>
+		<key name="scan_drbd_state_DELETED_explain">This disk was deleted.</key>
 		<key name="scan_drbd_state_failed_name">Failed</key>
 		<key name="scan_drbd_state_failed_explain">Transient state following an I/O failure report by the local block device. Next state: Diskless. Note: Despite the name, this is rarely an actual issue.</key>
 		<key name="scan_drbd_state_negotiating_name">Negotiating</key>

--- a/scancore-agents/scan-network/scan-network
+++ b/scancore-agents/scan-network/scan-network
@@ -462,6 +462,16 @@ sub collect_data
 	
 	$anvil->Network->get_ips({debug => 2});
 	
+	# Read the data from the ifcfg files, if available. We'll use this to check for bond interfaces that 
+	# didn't start.
+	$anvil->Network->check_network();
+	my $uptime = $anvil->Get->uptime();
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { uptime => $uptime }});
+	if ($uptime < 600)
+	{
+		$anvil->Network->read_nmcli({debug => 2})
+	}
+	
 	# The 'local_host' is needed to pull data recorded by Network->get_ips();
 	my $local_host = $anvil->Get->short_host_name();
 	my $directory  = "/sys/class/net";
@@ -1037,6 +1047,46 @@ sub collect_data
 				"new::interface::${interface}::tx_bytes"    => $anvil->data->{new}{interface}{$interface}{tx_bytes}." (".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{new}{interface}{$interface}{tx_bytes}}).")", 
 				"new::interface::${interface}::rx_bytes"    => $anvil->data->{new}{interface}{$interface}{rx_bytes}." (".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{new}{interface}{$interface}{rx_bytes}}).")", 
 			}});
+			
+			# On some occassions, an interface that is in a bond won't start. If the host uptime 
+			# is less than ten minutes, and a bond's member interface is down, up it.
+			if ($uptime < 600)
+			{
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					"nmcli::${local_host}::device_to_uuid::${interface}" => $anvil->data->{nmcli}{$local_host}{device_to_uuid}{$interface}, 
+				}});
+				my $uuid = $anvil->data->{nmcli}{$local_host}{device_to_uuid}{$interface};
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { uuid => $uuid }});
+				
+				if ($uuid)
+				{
+					my $state    = $anvil->data->{nmcli}{$local_host}{uuid}{$uuid}{'state'};
+					my $filename = $anvil->data->{nmcli}{$local_host}{uuid}{$uuid}{filename};
+					my $name     = ($filename =~ /ifcfg-(.*?)$/)[0];
+					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+						filename => $filename, 
+						name     => $name,
+						'state'  => $state,
+					}});
+					
+					if ($state ne "active")
+					{
+						# Try brinding the interface up.
+						$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "warning_0147", variables => { 
+							interface => $interface, 
+							uptime    => $uptime,
+						}});
+						
+						my $shell_call = $anvil->data->{path}{exe}{ifup}." ".$name;
+						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+						my ($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+							output      => $output,
+							return_code => $return_code, 
+						}});
+					}
+				}
+			}
 		}
 		
 		# Record the IP address info.

--- a/share/words.xml
+++ b/share/words.xml
@@ -3265,6 +3265,7 @@ The error was:
 #!variable!error!#
 ========
 		</key>
+		<key name="warning_0147">[ Warning ] - The interface: [#!variable!interface!#] is in a bond, but it is down. The system uptime is: [#!variable!uptime!#], so it might be a problem where the interface didn't start on boot as it should have. So we're going to bring the interface up.</key>
 
 		<!-- The entries below here are not sequential, but use a key to find the entry. -->
 		<!-- Run 'striker-parse-os-list to find new entries. --> 

--- a/share/words.xml
+++ b/share/words.xml
@@ -511,6 +511,7 @@ The output, if any, was;
 		<key name="error_0363">There are two or more entries on the host: [#!variable!host!#] in the history table: [#!variable!table!#]! The duplicate modidied_date and column UUID are: [#!variable!key!#] (time is UTC), and the query that exposed the dupplicate was: [#!variable!query!#]. This is likely caused by two database writes where the 'modified_date' wasn't updated between writes.</key>
 		<key name="error_0364">[ Error ] - There was a problem purging records. The details of the problem should be in the logs.</key>
 		<key name="error_0365">The table: [#!variable!table!#] has an entry in the history schema that doesn't have a corresponding record in the public schema. This is likely a resync artifact of a deleted record. Purging the record: [#!variable!uuid_column!#:#!variable!column_uuid!#] from all databases.</key>
+		<key name="error_0366">[ Error ] - Failed to reconnect to the database, and now no connections remain.</key>
 		
 		<!-- Files templates -->
 		<!-- NOTE: Translating these files requires an understanding of which lines are translatable -->
@@ -1554,7 +1555,7 @@ The database connection error was:
 		<key name="log_0193">Switching the default database handle to use the database: [#!variable!server!#] prior to reconnect attempt.</key>
 		<key name="log_0194">Switching the default database to read from to the database: [#!variable!server!#] prior to reconnect attempt.</key>
 		<key name="log_0195">Ready to try to reconnect to: [#!variable!server!#], but delaying for: [#!variable!delay!#] seconds to give the database a chance to come back online in case this is a transient issue.</key>
-		<key name="log_0196">Failed to reconnect to the database, and now no connections remail. Exiting.</key>
+		<key name="log_0196">The reboot flag was set. Rebooting NOW!</key>
 		<key name="log_0197"><![CDATA[System->maintenance_mode() was passed an invalid 'set' value: [#!variable!set!#]. No action taken.]]></key>
 		<key name="log_0198">The user: [#!variable!user!#] logged out successfully.</key>
 		<key name="log_0199">A system reboot has been requested via the Striker UI.</key>
@@ -2143,6 +2144,13 @@ The file: [#!variable!file!#] needs to be updated. The difference is:
 		<key name="log_0714">Closing the firewall port: [#!variable!port!#/#!variable!protocol!#] for the zone: [#!variable!zone!#]!</key>
 		<key name="log_0715">Closing the firewall port range: [#!variable!port!#/#!variable!protocol!#] for the zone: [#!variable!zone!#]!</key>
 		<key name="log_0716">Changes were made to the firewall, reloading now.</key>
+		<key name="log_0717">This server will boot: [#!variable!delay!#] after the server: [#!variable!server!#]. Checking if it's time to boot it or not.</key>
+		<key name="log_0718">The server: [#!variable!boot_after_server!#] hasn't booted yet, holding off booting: [#!variable!this_server!#].</key>
+		<key name="log_0719">Evaluating the booting of the server: [#!variable!server!#].</key>
+		<key name="log_0720">The server: [#!variable!boot_after_server!#] has booted, but we need to wait: [#!variable!time_to_wait!#] seconds before we can start this server: [#!variable!this_server!#].</key>
+		<key name="log_0721">The server: [#!variable!server!#] is ready to boot.</key>
+		<key name="log_0722">The server: [#!variable!server!#] was found to be running already, but it wasn't marked as booted. Marking it as if it just booted to handle any dependent servers.</key>
+		<key name="log_0723">The server: [#!variable!server!#] is configured to stay off, ignoring it.</key>
 		
 		<!-- Messages for users (less technical than log entries), though sometimes used for logs, too. -->
 		<key name="message_0001">The host name: [#!variable!target!#] does not resolve to an IP address.</key>

--- a/tools/anvil-boot-server
+++ b/tools/anvil-boot-server
@@ -189,7 +189,7 @@ sub wait_for_pacemaker
 	my $waiting = 1;
 	while($waiting)
 	{
-		my $problem = $anvil->Cluster->parse_cib({debug => 2});
+		my $problem = $anvil->Cluster->parse_cib({debug => 3});
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { problem => $problem }});
 		if (not $problem)
 		{
@@ -328,29 +328,171 @@ sub boot_all_servers
 		return(0);
 	}
 	
+	# Load information about the servers on this Anvil!.
+	my $anvil_uuid = $anvil->data->{sys}{anvil_uuid};
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { anvil_uuid => $anvil_uuid }});
+	
 	my $increment = int(70 / $server_count);
 	my $percent   = 15;
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { increment => $increment }});
-	foreach my $server (sort {$a cmp $b} keys %{$anvil->data->{cib}{parsed}{data}{server}})
+	
+	# Loop until all are processed.
+	my $waiting    = 1;
+	my $start_time = time;
+	while($waiting)
 	{
-		my $status    = $anvil->data->{cib}{parsed}{data}{server}{$server}{status};
-		my $host_name = $anvil->data->{cib}{parsed}{data}{server}{$server}{host_name};
-		my $role      = $anvil->data->{cib}{parsed}{data}{server}{$server}{role};
-		my $active    = $anvil->data->{cib}{parsed}{data}{server}{$server}{active};
-		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
-			's1:server'    => $server,
-			's2:status'    => $status,
-			's2:host_name' => $host_name,
-			's4:role'      => $role,
-			's5:active'    => $active, 
-		}});
+		# Get a list of servers now.
+		$anvil->Database->get_servers({debug => 3});
 		
-		if ($status eq "off")
+		# This will get set to 0 if any servers are waiting to boot.
+		my $all_processed = 1;
+		foreach my $server_name (sort {$a cmp $b} keys %{$anvil->data->{cib}{parsed}{data}{server}})
 		{
-			# Boot it.
-			my $wait    =  $anvil->data->{switches}{'wait'} ? 1 : 0;
-			   $percent += $increment;
-			boot_server($anvil, $server, $wait, $percent);
+			my $status      = $anvil->data->{cib}{parsed}{data}{server}{$server_name}{status};
+			my $host_name   = $anvil->data->{cib}{parsed}{data}{server}{$server_name}{host_name};
+			my $role        = $anvil->data->{cib}{parsed}{data}{server}{$server_name}{role};
+			my $active      = $anvil->data->{cib}{parsed}{data}{server}{$server_name}{active};
+			my $server_uuid = $anvil->data->{servers}{anvil_uuid}{$anvil_uuid}{server_name}{$server_name}{server_uuid};
+			my $boot_delay  = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_start_delay};
+			   $boot_delay  = 0 if not $boot_delay;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				's1:server_name' => $server_name,
+				's2:status'      => $status,
+				's2:host_name'   => $host_name,
+				's4:role'        => $role,
+				's5:active'      => $active, 
+				's6:server_uuid' => $server_uuid, 
+				's7:boot_delay'  => $boot_delay, 
+			}});
+			
+			if (not exists $anvil->data->{boot_server}{$server_name}{processed})
+			{
+				# This will get set to the boot time once we actually start it. This will let
+				# us time when servers that boot after this server can boot.
+				$anvil->data->{boot_server}{$server_name}{processed} = 0;
+			}
+			elsif ($anvil->data->{boot_server}{$server_name}{processed})
+			{
+				# Already processed.
+				next;
+			}
+			$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0719", variables => { server => $server_name }});
+			
+			my $boot_after_server_uuid = $anvil->data->{servers}{server_uuid}{$server_uuid}{server_start_after_server_uuid};
+			   $boot_after_server_uuid = "" if not defined $boot_after_server_uuid;
+			   $boot_after_server_uuid = "" if $boot_after_server_uuid eq "NULL";
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { boot_after_server_uuid => $boot_after_server_uuid }});
+			if ($boot_after_server_uuid)
+			{
+				if ($boot_after_server_uuid eq "00000000-0000-0000-0000-000000000000")
+				{
+					# This server is configured to stay off. 
+					$anvil->data->{boot_server}{$server_name}{processed} = time;
+					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+						"boot_server::${server_name}::processed" => $anvil->data->{boot_server}{$server_name}{processed},
+					}});
+					
+					$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0723", variables => { server => $server_name }});
+					next;
+				}
+				
+				# What's the server's name.
+				my $boot_after_server_name = $anvil->data->{servers}{server_uuid}{$boot_after_server_uuid}{server_name};
+				   $boot_after_server_name = "" if not defined $boot_after_server_name;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { boot_after_server_name => $boot_after_server_name }});
+				
+				# Has this server processed?
+				if ($boot_after_server_name)
+				{
+					$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0717", variables => { 
+						delay  => $boot_delay, 
+						server => $boot_after_server_name,
+					}});
+					if (not exists $anvil->data->{boot_server}{$boot_after_server_name})
+					{
+						$anvil->data->{boot_server}{$boot_after_server_name}{processed} = 0;
+						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+							"boot_server::${boot_after_server_name}::processed" => $anvil->data->{boot_server}{$boot_after_server_name}{processed},
+						}});
+					}
+					
+					if ($anvil->data->{boot_server}{$boot_after_server_name}{processed})
+					{
+						my $processed_seconds_ago = time - $anvil->data->{boot_server}{$boot_after_server_name}{processed};
+						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { processed_seconds_ago => $processed_seconds_ago }});
+						if ($processed_seconds_ago > $boot_delay)
+						{
+							# Ready to boot.
+							$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0721", variables => { server => $server_name }});
+						}
+						else
+						{
+							# Not ready yet.
+							$all_processed = 0;
+							$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { all_processed => $all_processed }});
+							
+							my $time_to_wait = $boot_delay - $processed_seconds_ago;
+							$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0720", variables => { 
+								boot_after_server => $boot_after_server_name,
+								this_server       => $server_name,
+								time_to_wait      => $time_to_wait,
+							}});
+							next;
+						}
+					}
+					else
+					{
+						# The other server hasn't processed yet.
+						$all_processed = 0;
+						$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { all_processed => $all_processed }});
+						
+						$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0718", variables => { 
+							boot_after_server => $boot_after_server_name,
+							this_server       => $server_name,
+						}});
+						next; 
+					}
+				}
+			}
+			
+			if ($status eq "off")
+			{
+				# Boot it.
+				my $wait    =  $anvil->data->{switches}{'wait'} ? 1 : 0;
+				   $percent += $increment;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					'wait'  => $wait,
+					percent => $percent, 
+				}});
+				boot_server($anvil, $server_name, $wait, $percent);
+				
+				# If we're here, the server processed. 
+				$anvil->data->{boot_server}{$server_name}{processed} = time;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					"boot_server::${server_name}::processed" => $anvil->data->{boot_server}{$server_name}{processed}, 
+				}});
+			}
+			elsif (not $anvil->data->{boot_server}{$server_name}{processed})
+			{
+				# It may have booted before we ran.
+				$anvil->data->{boot_server}{$server_name}{processed} = time;
+				$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0722", variables => { server => $server_name }});
+			}
+		}
+		
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { all_processed => $all_processed }});
+		if ($all_processed)
+		{
+			# We're done!
+			$waiting = 0;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { waiting => $waiting }});
+		}
+		else
+		{
+			# Wait a bit.
+			sleep 2;
+			my $problem = $anvil->Cluster->parse_cib({debug => 3});
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { problem => $problem }});
 		}
 	}
 	

--- a/tools/anvil-boot-server
+++ b/tools/anvil-boot-server
@@ -27,20 +27,9 @@ $| = 1;
 
 my $anvil = Anvil::Tools->new();
 
-$anvil->data->{switches}{'job-uuid'}    = "";
-$anvil->data->{switches}{'no-wait'}     = "";	# When set, we'll not wait when we boot a single server
-$anvil->data->{switches}{'server'}      = "";
-$anvil->data->{switches}{'server-uuid'} = "";
-$anvil->data->{switches}{'wait'}        = "";	# When set, we'll wait for each server we boot when using '--all'
-$anvil->Get->switches;
+$anvil->Get->switches({list => ["job-uuid", "no-wait", "server", "server-uuid", ""], man => $THIS_FILE});
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0115", variables => { program => $THIS_FILE }});
-$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
-	'switches::job-uuid'    => $anvil->data->{switches}{'job-uuid'}, 
-	'switches::no-wait'     => $anvil->data->{switches}{'no-wait'}, 
-	'switches::server'      => $anvil->data->{switches}{'server'},
-	'switches::server-uuid' => $anvil->data->{switches}{'server-uuid'}, 
-	'switches::wait'        => $anvil->data->{switches}{'wait'}, 
-}});
 
 $anvil->Database->connect();
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 3, secure => 0, key => "log_0132"});

--- a/tools/anvil-boot-server
+++ b/tools/anvil-boot-server
@@ -27,7 +27,7 @@ $| = 1;
 
 my $anvil = Anvil::Tools->new();
 
-$anvil->Get->switches({list => ["job-uuid", "no-wait", "server", "server-uuid", ""], man => $THIS_FILE});
+$anvil->Get->switches({list => ["job-uuid", "no-wait", "server", "server-uuid", "wait"], man => $THIS_FILE});
 $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0115", variables => { program => $THIS_FILE }});
 

--- a/tools/anvil-change-password
+++ b/tools/anvil-change-password
@@ -40,7 +40,8 @@ if (($< != 0) && ($> != 0))
 	$anvil->nice_exit({exit_code => 1});
 }
 
-$anvil->Get->switches;
+$anvil->Get->switches({list => ["anvil", "new-password", "password-file", "y", "yes"], man => $THIS_FILE});
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 3, secure => 0, key => "log_0115", variables => { program => $THIS_FILE }});
 
 # Connect

--- a/tools/anvil-check-memory
+++ b/tools/anvil-check-memory
@@ -32,11 +32,8 @@ $| = 1;
 
 my $anvil = Anvil::Tools->new();
 
-$anvil->data->{switches}{program} = ""; 
-$anvil->Get->switches;
-$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
-	'switches::program' => $anvil->data->{switches}{program}, 
-}});
+$anvil->Get->switches({list => ["program"], man => $THIS_FILE});
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
 
 $anvil->data->{memory}{total} = 0;
 

--- a/tools/anvil-configure-host
+++ b/tools/anvil-configure-host
@@ -36,11 +36,8 @@ $| = 1;
 my $anvil = Anvil::Tools->new();
 
 # Read switches
-$anvil->Get->switches;
-### TODO: Remove this before final release
-$anvil->Log->level({set => 2});
-$anvil->Log->secure({set => 1});
-##########################################
+$anvil->Get->switches({list => ["job-uuid"], man => $THIS_FILE});
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
 
 # Make sure we're running as 'root'
 # $< == real UID, $> == effective UID

--- a/tools/anvil-configure-host
+++ b/tools/anvil-configure-host
@@ -1242,6 +1242,7 @@ sub reconfigure_network
 	{
 		# In an attempt to make network changes more reliable, we'll just reboot. This shouldn't 
 		# actually be hit anymore as any change should have triggered the reboot above.
+		$anvil->data->{sys}{reboot} = 1;
 		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, 'print' => 1, key => "log_0687", variables => { reason => "#!string!log_0631!#" }});
 		do_reboot($anvil);
 		

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -1194,6 +1194,8 @@ sub check_firewall
 {
 	my ($anvil) = @_;
 	
+	return(0);
+	
 	# Don't call this if we're not configured yet.
 	my $configured = $anvil->System->check_if_configured({debug => 3});
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { configured => $configured }});

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -139,13 +139,8 @@ if (not $anvil->data->{sys}{database}{connections})
 }
 
 # Read switches
-$anvil->data->{switches}{'refresh-json'}   = "";
-$anvil->data->{switches}{'run-once'}       = 0;
-$anvil->data->{switches}{'main-loop-only'} = 0;
-$anvil->data->{switches}{'no-start'}       = 0;
-$anvil->data->{switches}{'purge'}          = 0;
-$anvil->data->{switches}{'startup-only'}   = 0;
-$anvil->Get->switches;
+$anvil->Get->switches({list => ["?", "help", "h", "refresh-json", "run-once", "main-loop-only", "no-start", "purge", "startup-only"], man => $THIS_FILE});
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
 
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0115", variables => { program => $THIS_FILE }});
 
@@ -154,6 +149,11 @@ if ($anvil->data->{switches}{'refresh-json'})
 	$anvil->data->{switches}{'run-once'}       = 1;
 	$anvil->data->{switches}{'main-loop-only'} = 1;
 	$anvil->data->{switches}{'no-start'}       = 1;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		"switches::run-once"       => $anvil->data->{switches}{'run-once'}, 
+		"switches::main-loop-only" => $anvil->data->{switches}{'main-loop-only'}, 
+		"switches::no-start"       => $anvil->data->{switches}{'no-start'}, 
+	}});
 }
 
 # This is used to track initial checkes / repairs of network issues.

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -117,9 +117,8 @@ if (not $anvil->data->{sys}{database}{connections})
 }
 
 # Read switches
-$anvil->Get->switches({list => ["?", "help", "h", "refresh-json", "run-once", "main-loop-only", "no-start", "startup-only"], man => $THIS_FILE});
+$anvil->Get->switches({list => ["refresh-json", "run-once", "main-loop-only", "no-start", "startup-only"], man => $THIS_FILE});
 $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
-
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0115", variables => { program => $THIS_FILE }});
 
 if ($anvil->data->{switches}{'refresh-json'})

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -1432,14 +1432,15 @@ sub prep_database
 		}});
 		if ($prep_database)
 		{
-			### NOTE: This failed once, in case / until it happens again, we'll force log level 2 and secure logging.
-			my $shell_call = $anvil->data->{path}{exe}{'striker-prep-database'}." -vv --log-secure";
-			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
-			my ($database_output, $return_code) = $anvil->System->call({debug => 2, shell_call => $shell_call, source => $THIS_FILE, line => __LINE__ });
-			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
-				database_output => $database_output,
-				return_code     => $return_code, 
-			}});
+			$anvil->Database->configure_pgsql({debug => 2})
+# 			### NOTE: This failed once, in case / until it happens again, we'll force log level 2 and secure logging.
+# 			my $shell_call = $anvil->data->{path}{exe}{'striker-prep-database'}." -vv --log-secure";
+# 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+# 			my ($database_output, $return_code) = $anvil->System->call({debug => 2, shell_call => $shell_call, source => $THIS_FILE, line => __LINE__ });
+# 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+# 				database_output => $database_output,
+# 				return_code     => $return_code, 
+# 			}});
 		}
 		elsif (not $anvil->data->{sys}{database}{connections})
 		{

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -25,28 +25,6 @@
 # - For later; 'reboot --force --force' immediately kills the OS, like disabling ACPI on EL6 and hitting the 
 #   power button. Might be useful in ScanCore down the road.
 # 
-# Switches:
-# 
-# --main-loop-only 
-# 
-#   This skips the one-time, start-up tasks and just goes into the main-loop,
-# 
-# --no-start
-# 
-#   This will prevent any pending jobs from being picked up and started in this run. Note that other job checks will still happen.
-# 
-# --refresh-json 
-#   
-#   This just updates the JSON files used by the web interface. It is the same as '--run-once --main-loop-only --no-start'
-#   
-# --run-once
-# 
-#   This will tell the program to exit after runn the main loop once.
-# 
-# --startup-only
-# 
-#   This will tell the program to exit after running the start up tasks, so the main loop won't run.
-# 
 
 use strict;
 use warnings;

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -139,7 +139,7 @@ if (not $anvil->data->{sys}{database}{connections})
 }
 
 # Read switches
-$anvil->Get->switches({list => ["?", "help", "h", "refresh-json", "run-once", "main-loop-only", "no-start", "purge", "startup-only"], man => $THIS_FILE});
+$anvil->Get->switches({list => ["?", "help", "h", "refresh-json", "run-once", "main-loop-only", "no-start", "startup-only"], man => $THIS_FILE});
 $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
 
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0115", variables => { program => $THIS_FILE }});

--- a/tools/anvil-delete-server
+++ b/tools/anvil-delete-server
@@ -29,10 +29,9 @@ my $anvil = Anvil::Tools->new();
 
 # Read switches (target ([user@]host[:port]) and the file with the target's password. If the password is 
 # passed directly, it will be used. Otherwise, the password will be read from the database.
-$anvil->data->{switches}{'job-uuid'} = "";
-$anvil->Get->switches;
+$anvil->Get->switches({list => ["job-uuid"], man => $THIS_FILE});
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 2, secure => 0, key => "log_0115", variables => { program => $THIS_FILE }});
-$anvil->Log->variables({source  => $THIS_FILE, line => __LINE__, level => 2, list => { 'switches::job-uuid' => $anvil->data->{switches}{'job-uuid'} }});
 
 $anvil->Database->connect();
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 3, secure => 0, key => "log_0132"});

--- a/tools/anvil-manage-firewall
+++ b/tools/anvil-manage-firewall
@@ -64,12 +64,20 @@ if ($anvil->data->{switches}{'job-uuid'})
 {
 	$anvil->Job->clear();
 	$anvil->Job->get_job_details();
+# 	$anvil->Job->update_progress({
+# 		progress         => 1,
+# 		job_picked_up_by => $$, 
+# 		job_picked_up_at => time, 
+# 		message          => "message_0134", 
+# 	});
 	$anvil->Job->update_progress({
-		progress         => 1,
+		progress         => 100,
 		job_picked_up_by => $$, 
 		job_picked_up_at => time, 
 		message          => "message_0134", 
 	});
+	
+	exit(0);
 	
 	if ($anvil->data->{jobs}{job_data} =~ /server=(.*)$/)
 	{
@@ -81,6 +89,7 @@ if ($anvil->data->{switches}{'job-uuid'})
 	}
 
 }
+exit(0);
 
 # This used to do all the work, but that's now moved to the method below. So all we do here now is call it.
 $anvil->Network->manage_firewall();

--- a/tools/anvil-network-profiler
+++ b/tools/anvil-network-profiler
@@ -1,0 +1,1107 @@
+#!/usr/bin/perl
+# 
+
+use strict;
+use warnings;
+use Anvil::Tools;
+use POSIX qw/ceil/;;
+use Data::Dumper;
+use Time::HiRes qw(usleep);
+
+my $THIS_FILE           =  ($0 =~ /^.*\/(.*)$/)[0];
+my $running_directory   =  ($0 =~ /^(.*?)\/$THIS_FILE$/)[0];
+if (($running_directory =~ /^\./) && ($ENV{PWD}))
+{
+	$running_directory =~ s/^\./$ENV{PWD}/;
+}
+
+# Turn off buffering so that the pinwheel will display while waiting for the SSH call(s) to complete.
+$| = 1;
+
+my $anvil = Anvil::Tools->new();
+
+$anvil->data->{switches}{'max-mtu'} = "";
+$anvil->data->{switches}{password}  = "";
+$anvil->data->{switches}{stepping}  = "";
+$anvil->data->{switches}{source}    = "";
+$anvil->data->{switches}{target}    = "";
+$anvil->data->{switches}{tests}     = "";
+$anvil->data->{switches}{y}         = "";
+$anvil->Get->switches;
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+	'switches::max-mtu'  => $anvil->data->{switches}{'max-mtu'},
+	'switches::password' => $anvil->Log->is_secure($anvil->data->{switches}{password}),
+	'switches::stepping' => $anvil->data->{switches}{stepping},
+	'switches::source'   => $anvil->data->{switches}{source},
+	'switches::target'   => $anvil->data->{switches}{target},
+	'switches::tests'    => $anvil->data->{switches}{tests},
+	'switches::y'        => $anvil->data->{switches}{y},
+}});
+
+checks($anvil);
+print "Checks passed, beginning.\n";
+
+if (not $anvil->data->{sys}{max_usable_mtu})
+{
+	find_maximum_usable_mtu($anvil);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		'sys::highest_good_mtu' => $anvil->data->{sys}{highest_good_mtu},
+	}});
+	if ($anvil->data->{sys}{highest_good_mtu} < 1500)
+	{
+		print "[ Error ] - The detected maximum usable MTU size appears invalid!\n";
+		print "[ Error ] - You may need to restore the default MTU of one or both nodes using:\n";
+		my $remote_shell_call = $anvil->data->{path}{exe}{nmcli}." connection modify \"".$anvil->data->{sys}{target_interface}{name}."\" 802-3-ethernet.mtu 1500 && ".$anvil->data->{path}{exe}{nmcli}." connection up \"".$anvil->data->{sys}{target_interface}{name}."\"";
+		my $local_shell_call  = $anvil->data->{path}{exe}{nmcli}." connection modify \"".$anvil->data->{sys}{source_interface}{name}."\" 802-3-ethernet.mtu 1500 && ".$anvil->data->{path}{exe}{nmcli}." connection up \"".$anvil->data->{sys}{source_interface}{name}."\"";
+		print "          remote: ".$local_shell_call."\n";
+		print "          local:  ".$remote_shell_call."\n\n";
+		$anvil->nice_exit({exit_code => 1});
+	}
+}
+else
+{
+	print "\nMaximum MTU for this network statically set to: [".$anvil->data->{sys}{max_usable_mtu}."]\n";
+}
+
+do_tests($anvil);
+
+print "All tests complete!\n\n";
+print "Graphs:\n\n";
+print_graphs($anvil);
+
+
+$anvil->nice_exit({exit_code => 0});
+
+#############################################################################################################
+# Functions                                                                                                 #
+#############################################################################################################
+
+sub print_graphs
+{
+	my ($anvil) = @_;
+	
+	$anvil->data->{sys}{highest_value} = 0;
+	$anvil->data->{sys}{peak_mtu}      = 0;
+	foreach my $mtu (keys %{$anvil->data->{iperf}{mtu}})
+	{
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { mtu => $mtu }});
+		foreach my $key (keys %{$anvil->data->{iperf}{mtu}{$mtu}{test}{avg}})
+		{
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				"iperf::mtu::${mtu}::test::avg::${key}" => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{$key},
+			}});
+			if ($anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{$key} > $anvil->data->{sys}{highest_value})
+			{
+				$anvil->data->{sys}{highest_value} = $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{$key};
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					"sys::highest_value" => $anvil->data->{sys}{highest_value},
+				}});
+			}
+		}
+	}
+	$anvil->data->{sys}{highest_value} = sprintf("%.1f", $anvil->data->{sys}{highest_value});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		"sys::highest_value" => $anvil->data->{sys}{highest_value},
+	}});
+	
+	$anvil->data->{sys}{peak_mtu}     = 0;
+	$anvil->data->{sys}{peak_average} = 0;
+	foreach my $mtu (sort {$a <=> $b} keys %{$anvil->data->{iperf}{mtu}})
+	{
+		if ($anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average} > $anvil->data->{sys}{peak_average})
+		{
+			$anvil->data->{sys}{peak_average} = $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average};
+			$anvil->data->{sys}{peak_mtu}     = $mtu;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				"sys::peak_average" => $anvil->data->{sys}{peak_average},
+				"sys::peak_mtu"     => $anvil->data->{sys}{peak_mtu},
+			}});
+		}
+	}
+	
+	my $columns = get_tput_cols($anvil);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { columns => $columns }});
+	
+	$anvil->data->{sys}{max_graph_width} = ($columns - 10);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		"sys::max_graph_width" => $anvil->data->{sys}{max_graph_width},
+	}});
+	foreach my $mtu (sort {$b cmp $a} keys %{$anvil->data->{iperf}{mtu}})
+	{
+		my $bar_minus = 7;
+		my $say_mtu   = sprintf("%4s", $mtu);
+		if (length($anvil->data->{sys}{max_usable_mtu}) == 5)
+		{
+			$bar_minus = 8;
+			$say_mtu   = sprintf("%5s", $mtu);
+		}
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			bar_minus => $bar_minus,
+			say_mtu   => $say_mtu, 
+		}});
+		print "[ ".$say_mtu." bytes ]";
+		for (0..($anvil->data->{sys}{max_graph_width} - $bar_minus))
+		{ 
+			print "-";
+		}
+		print "\n";
+		print " Tx: "; print_dots($anvil, $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth});
+		print " Rx: "; print_dots($anvil, $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth});
+		print "Avg: "; print_dots($anvil, $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average});
+	}
+	for (0..($anvil->data->{sys}{max_graph_width} + 8))
+	{ 
+		print "-";
+	}
+	print "\n";
+	print "The peak average bandwidth was: [".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{sys}{peak_average}})."], achieved with the MTU: [".$anvil->data->{sys}{peak_mtu}."]\n\n";
+	
+	return(0);
+}
+
+sub print_dots
+{
+	my ($anvil, $bandwidth) = @_;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { bandwidth => $bandwidth }});
+	
+	my $say_bandwidth = $anvil->Convert->bytes_to_human_readable({'bytes' => $bandwidth});
+	my $overhead      = 9;
+	my $less_dots     = 4 + $overhead;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		say_bandwidth        => $say_bandwidth,
+		'sys::highest_value' => $anvil->data->{sys}{highest_value}, 
+	}});
+	if (length($anvil->data->{sys}{highest_value}) == 7)
+	{
+		$say_bandwidth = sprintf("%7s", $say_bandwidth);
+		$less_dots     = 6 + $overhead;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			say_bandwidth => $say_bandwidth,
+			less_dots     => $less_dots, 
+		}});
+	}
+	elsif (length($anvil->data->{sys}{highest_value}) == 6)
+	{
+		$say_bandwidth = sprintf("%6s", $say_bandwidth);
+		$less_dots     = 6 + $overhead;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			say_bandwidth => $say_bandwidth,
+			less_dots     => $less_dots, 
+		}});
+	}
+	elsif (length($anvil->data->{sys}{highest_value}) == 5)
+	{
+		$say_bandwidth = sprintf("%5s", $say_bandwidth);
+		$less_dots     = 5 + $overhead;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			say_bandwidth => $say_bandwidth,
+			less_dots     => $less_dots, 
+		}});
+	}
+	else
+	{
+		$say_bandwidth = sprintf("%4s", $say_bandwidth);
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { say_bandwidth => $say_bandwidth }});
+	}
+	my $percent = sprintf("%.0f", (($bandwidth / $anvil->data->{sys}{highest_value}) * 100));
+	my $dots    = $anvil->data->{sys}{max_graph_width} * ($percent / 100);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		percent => $percent,
+		dots    => $dots,
+	}});
+	
+	print " ".$say_bandwidth."/sec |";
+	
+	my $full_dot  = $dots;
+	my $remainder = 0;
+	if ($dots =~ /(\d+)\.(\d)/)
+	{
+		$full_dot  = $1;
+		$remainder = $2;
+	}
+	
+	if ($full_dot > $less_dots)
+	{
+		$full_dot -= $less_dots;
+		for (0..$full_dot)
+		{
+			print "#";
+		}
+		if (($remainder > 3) && ($remainder < 7))
+		{
+			print ">";
+		}
+	}
+	print "\n";
+	
+	return(0);
+}
+
+sub get_tput_cols
+{
+	my ($anvil) = @_;
+	
+	my $columns = 80;
+	
+	# This can't be called through IO::Handle as it always returns 80.
+	my $shell_call = $anvil->data->{path}{exe}{tput}." cols";
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+	
+	$columns = `$shell_call`;
+	chomp $columns;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { columns => $columns }});
+	
+	return ($columns);
+}
+
+sub do_tests
+{
+	my ($anvil) = @_;
+	print "\n-=] Beginning 'iperf' testing, averaging: [".$anvil->data->{sys}{iperf_test_count}."] tests.\n\n";
+	
+	# Current MTU size to test.
+	my $iperf_mtu = 1500;
+	
+	# Give the user an idea of how long they have to go make coffee.
+	my $skipped_iterations = (($anvil->data->{sys}{min_usable_mtu} / $anvil->data->{sys}{iperf_mtu_stepping}) - 1);
+	my $total_iterations   = ceil($anvil->data->{sys}{highest_good_mtu} / $anvil->data->{sys}{iperf_mtu_stepping});
+	my $actual_iterations  = ($total_iterations - $skipped_iterations);
+	my $per_test_time      = ($anvil->data->{sys}{iperf_test_count} * 20);	# 10sec per half/full duplex.
+	my $total_seconds      = $actual_iterations * $per_test_time;
+	my $total_minutes      = $total_seconds / 60;
+	   $total_minutes      = sprintf("%.1f", $total_minutes);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		's1:skipped_iterations' => $skipped_iterations,
+		's2:total_iterations'   => $total_iterations,
+		's3:actual_iterations'  => $actual_iterations,
+		's4:per_test_time'      => $per_test_time,
+		's5:total_seconds'      => $total_seconds,
+		's6:total_minutes'      => $total_minutes,
+	}});
+	print "Please be patient. I expect this will take roughly: [".$total_minutes." minutes].\n";
+	print " - Time needed to change the MTU will add to this estimated time.\n";
+
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		iperf_mtu               => $iperf_mtu,
+		"sys::highest_good_mtu" => $anvil->data->{sys}{highest_good_mtu},
+	}});
+	while ($iperf_mtu <= $anvil->data->{sys}{highest_good_mtu})
+	{
+		run_iperf_tests($anvil, $iperf_mtu);
+		
+		# I want to always test the maximum MTU, which this will do.
+		if ($iperf_mtu != $anvil->data->{sys}{highest_good_mtu})
+		{
+			$iperf_mtu += $anvil->data->{sys}{iperf_mtu_stepping};
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { iperf_mtu => $iperf_mtu }});
+			if ($iperf_mtu > $anvil->data->{sys}{highest_good_mtu})
+			{
+				$iperf_mtu = $anvil->data->{sys}{highest_good_mtu};
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { iperf_mtu => $iperf_mtu }});
+			}
+		}
+		else
+		{
+			# Done.
+			last;
+		}
+	}
+	
+	return(0);
+}
+
+sub run_iperf_tests
+{
+	my ($anvil, $mtu) = @_;
+	
+	print "\nTesting iperf at MTU: [".$mtu." Bytes];\n";
+	my ($new_remote_mtu) = alter_mtu($anvil, "remote", $mtu);
+	if ($mtu ne $new_remote_mtu)
+	{
+		print "[ ERROR ] I was unable change the MTU up to: [".$mtu."] on remote.\n";
+		print "[ ERROR ] Still at an MTU of: [".$mtu."].\n\n";
+		exit 5;
+	}
+	my ($new_local_mtu) = alter_mtu($anvil, "local", $mtu);
+	if ($mtu ne $new_local_mtu)
+	{
+		print "[ ERROR ] I was unable change the MTU up to: [".$mtu."] on local.\n";
+		print "[ ERROR ] Still at an MTU of: [".$mtu."].\n\n";
+		exit 6;
+	}
+	
+	# Beginning Tests:
+	my $iperf_test_count = $anvil->data->{sys}{iperf_test_count};
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { iperf_test_count => $iperf_test_count }});
+	foreach my $i (1..$iperf_test_count)
+	{
+		($anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{tx_seconds},
+		 $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{tx_transfer}, 
+		 $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{tx_bandwidth},
+		 $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{rx_seconds}, 
+		 $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{rx_transfer}, 
+		 $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{rx_bandwidth}) = call_iperf($anvil, $i);
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			"s1:iperf::mtu::${mtu}::test::${i}::tx_seconds"   => $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{tx_seconds},
+			"s2:iperf::mtu::${mtu}::test::${i}::tx_transfer"  => $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{tx_transfer},
+			"s3:iperf::mtu::${mtu}::test::${i}::tx_bandwidth" => $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{tx_bandwidth},
+			"s4:iperf::mtu::${mtu}::test::${i}::rx_seconds"   => $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{rx_seconds},
+			"s5:iperf::mtu::${mtu}::test::${i}::rx_transfer"  => $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{rx_transfer},
+			"s6:iperf::mtu::${mtu}::test::${i}::rx_bandwidth" => $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{rx_bandwidth},
+		}});
+		print " - [".$i."/".$iperf_test_count."]; Transmit: [".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{tx_bandwidth}})."/sec], Receive: [".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{rx_bandwidth}})."/sec]\n";
+		
+		# Add to the totals for later averaging.
+		$anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth} += $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{tx_bandwidth};
+		$anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth} += $anvil->data->{iperf}{mtu}{$mtu}{test}{$i}{rx_bandwidth};
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			"s1:iperf::mtu::${mtu}::test::avg::tx_bandwidth" => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth},
+			"s2:iperf::mtu::${mtu}::test::avg::rx_bandwidth" => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth},
+		}});
+	}
+	print "Done!\n";
+	
+	# Average sums.
+	$anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth}  /= $iperf_test_count;
+	$anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth}  /= $iperf_test_count;
+	$anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average}  = ($anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth} + $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth}) / 2;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		"s1:iperf::mtu::${mtu}::test::avg::tx_bandwidth"  => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth},
+		"s2:iperf::mtu::${mtu}::test::avg::rx_bandwidth"  => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth},
+		"s3:iperf::mtu::${mtu}::test::avg::total_average" => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average},
+	}});
+	
+	# Round to zero
+	$anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth}  = $anvil->Convert->round({number => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth}});
+	$anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth}  = $anvil->Convert->round({number => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth}});
+	$anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average} = $anvil->Convert->round({number => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average}});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		"s1:iperf::mtu::${mtu}::test::avg::tx_bandwidth"  => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth}." Bytes/Sec (".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth}}).")",
+		"s2:iperf::mtu::${mtu}::test::avg::rx_bandwidth"  => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth}." Bytes/Sec (".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth}}).")",
+		"s3:iperf::mtu::${mtu}::test::avg::total_average" => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average}." Bytes/Sec (".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average}}).")",
+	}});
+	
+# 	# Report average
+	print " - Average TX: [".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{tx_bandwidth}})."/sec], RX: [".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{rx_bandwidth}})."/sec], Total Average: [".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{iperf}{mtu}{$mtu}{test}{avg}{total_average}})."/sec]\n";
+	
+	return(0);
+}
+
+sub call_iperf
+{
+	my ($anvil, $test)=@_;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		test => $test,
+	}});
+	
+	# Start the daemon on the peer.
+	my $shell_call = $anvil->data->{path}{exe}{iperf3}." --server --daemon --one-off";
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+	my ($output, $error, $return_code) = $anvil->Remote->call({
+		target     => $anvil->data->{switches}{target}, 
+		password   => $anvil->data->{switches}{password},
+		shell_call => $shell_call,
+	});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		output      => $output, 
+		error       => $error, 
+		return_code => $return_code,
+	}});
+	
+	# Sleep for a short time to make sure the server has started and is listening.
+	usleep($anvil->data->{sys}{iperf_micro_sleep});
+	
+	# Now call iperf3 locally. 
+	# Get the output in Kbps, running for 11 seconds, discarding the first 1 second to ignore TCP ramp up
+	   $shell_call             = $anvil->data->{path}{exe}{iperf3}." --client ".$anvil->data->{switches}{target}." --format K --interval 0 --time 11 --omit 1 ";
+	   ($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		output      => $output,
+		return_code => $return_code, 
+	}});
+	foreach my $line (split/\n/, $output)
+	{
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { line => $line }});
+	}
+	
+=cut
+Connecting to host 192.168.122.251, port 5201
+[  5] local 192.168.122.252 port 41998 connected to 192.168.122.251 port 5201
+[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5]   0.00-11.00  sec  78.9 GBytes  7524333 KBytes/sec    0   3.01 MBytes       
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-11.00  sec  78.9 GBytes  7524333 KBytes/sec    0             sender
+[  5]   0.00-11.04  sec  79.2 GBytes  7521387 KBytes/sec                  receiver
+
+iperf Done.
+=cut
+
+	my $tx_seconds   = 0;
+	my $tx_transfer  = 0;
+	my $tx_bandwidth = 0;
+	my $rx_seconds   = 0;
+	my $rx_transfer  = 0;
+	my $rx_bandwidth = 0;
+	foreach my $line (split/\n/, $output)
+	{
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { line => $line }});
+		if ($line =~ /0.00-(\d+.*?)\s+sec\s+(\d+.* \wBytes)\s+(\d+)\s+KBytes\/sec/)
+		{
+			my $seconds   = $1;
+			my $transfer  = $2;
+			my $bandwidth = $3;
+			if ($line =~ / sender$/)
+			{
+				$tx_seconds   = $seconds - 1;
+				$tx_transfer  = $transfer;
+				$tx_bandwidth = $bandwidth;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					tx_seconds   => $tx_seconds,
+					tx_transfer  => $tx_transfer, 
+					tx_bandwidth => $tx_bandwidth, 
+				}});
+			}
+			elsif ($line =~ / receiver$/)
+			{
+				$rx_seconds   = $seconds - 1;
+				$rx_transfer  = $transfer;
+				$rx_bandwidth = $bandwidth;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					rx_seconds   => $tx_seconds,
+					rx_transfer  => $tx_transfer, 
+					rx_bandwidth => $tx_bandwidth, 
+				}});
+			}
+		}
+	}
+	
+	# Convert from KBytes to Bytes
+	$tx_bandwidth = $anvil->Convert->human_readable_to_bytes({size => $tx_bandwidth, type => "KiB"});
+	$rx_bandwidth = $anvil->Convert->human_readable_to_bytes({size => $rx_bandwidth, type => "KiB"});
+
+	return ($tx_seconds, $tx_transfer, $tx_bandwidth, $rx_seconds, $rx_transfer, $rx_bandwidth);
+}
+
+sub find_maximum_usable_mtu
+{
+	my ($anvil) = @_;
+	
+	# Test the initial MTU of 1500.
+	print "Initial test with an MTU of '1500' to confirm testing method;\n";
+	
+	# This is the increment, in bytes starting at 1500, that the MTU will be raised to the maximum.
+	$anvil->data->{sys}{iperf_mtu_stepping} = 500;
+	
+	# This sets a maximum MTU to test for. It is useful if setting a too-high MTU will break the network
+	# link.
+	$anvil->data->{sys}{mtu_maximum} = 9000;
+	
+	# If set to 0, the program will roughly detect the maximum MTU. If set, the value becomes the maximum
+	# MTU (and assumes you've already ensured that your interfaces and network infrastructure handle it).
+	$anvil->data->{sys}{max_usable_mtu} = 0;
+	if ($anvil->data->{switches}{'max-mtu'})
+	{
+		if (($anvil->data->{switches}{'max-mtu'} =~ /^\d+$/) && ($anvil->data->{switches}{'max-mtu'} > 1500))
+		{
+			$anvil->data->{sys}{max_usable_mtu} = $anvil->data->{switches}{'max-mtu'};
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				"sys::max_usable_mtu" => $anvil->data->{sys}{max_usable_mtu},
+			}});
+		}
+		else
+		{
+			print "[ Error ] - The '--max-mtu' was set to: [".$anvil->data->{switches}{'max-mtu'}."] which is invalid. It must be a whole number larger than 1500.\n";
+			$anvil->nice_exit({exit_code => 1});
+		}
+	}
+	
+	# This is the minimum MTU. It should never change from 1500.
+	$anvil->data->{sys}{min_usable_mtu} = 1500;
+	
+	# This is the ICMP overhead to subtract from TCP payload sizes.
+	$anvil->data->{sys}{icmp_overhead}     = 28;
+	$anvil->data->{sys}{icmp_mtu_stepping} = 100;
+	
+	# This is used to re-check pings to avoid early failures caused by stray packets.
+	$anvil->data->{sys}{fail_count} = 0;
+	$anvil->data->{sys}{fail_limit} = 3;
+	
+	# After calling iperf on the remote node, I need to wait a short time listener to be ready. This sets
+	# the delays in millionths of a second.
+	$anvil->data->{sys}{iperf_micro_sleep} = 100000;
+	
+	# This is how many times I run each iperf test. An average of the results is stored.
+	$anvil->data->{sys}{iperf_test_count} = 3;
+	if ($anvil->data->{switches}{tests})
+	{
+		if (($anvil->data->{switches}{tests} =~ /^\d+$/) && ($anvil->data->{switches}{tests} > 1))
+		{
+			$anvil->data->{sys}{iperf_test_count} = $anvil->data->{switches}{tests};
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				"sys::iperf_test_count" => $anvil->data->{sys}{iperf_test_count},
+			}});
+		}
+		else
+		{
+			print "[ Error ] - The '--tests' was set to: [".$anvil->data->{switches}{tests}."] which is invalid. It must be a whole number larger than 1.\n";
+			$anvil->nice_exit({exit_code => 1});
+		}
+	}
+	
+	# This will store the top tested good MTU
+	$anvil->data->{sys}{highest_good_mtu} = 1500;
+	
+	# Initial tests.
+	my $test_mtu = 1500;
+	my $ok       = set_mtu_and_ping($anvil, $test_mtu, 0);
+	if (not $ok)
+	{
+		print "[ Error ] - Unable to run ping-based tests! Is the network up?\n";
+		return($anvil->data->{sys}{highest_good_mtu});
+	}
+	$anvil->data->{tested}{$test_mtu} = "";
+	
+	# This will catch an attempt to repeat a test and break the loop.
+	my $difference = $anvil->data->{sys}{mtu_maximum} - $anvil->data->{sys}{min_usable_mtu};
+	   $test_mtu   = $anvil->data->{sys}{mtu_maximum};
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		difference => $difference,
+		test_mtu   => $test_mtu,
+	}});
+	foreach my $i (1..1000)
+	{
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			's1:i'        => $i,
+			's2:test_mtu' => $test_mtu, 
+		}});
+		if ((exists $anvil->data->{tested}{$test_mtu}) && ($anvil->data->{tested}{$test_mtu}))
+		{
+			last;
+		}
+		
+		# Test this MTU.
+		print " - Testing with an MTU of: [".$test_mtu."];\n";
+		my $ok = set_mtu_and_ping($anvil, $test_mtu, 0);
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { ok => $ok }});
+		
+		if (($i == 1) && ($ok))
+		{
+			# Highest allowable MTU is OK.
+			$anvil->data->{sys}{highest_good_mtu} = $test_mtu;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				"sys::highest_good_mtu" => $anvil->data->{sys}{highest_good_mtu},
+			}});
+			last;
+		}
+		
+		if ($ok)
+		{
+			$anvil->data->{tested}{$test_mtu}     = 'ok';
+			$anvil->data->{sys}{highest_good_mtu} = $test_mtu;
+			$test_mtu                             = ($test_mtu + ($difference / 2**$i));
+			$test_mtu                             = round_to_100($anvil, $test_mtu);
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				"tested::$test_mtu"     => $anvil->data->{tested}{$test_mtu},
+				"sys::highest_good_mtu" => $anvil->data->{sys}{highest_good_mtu}, 
+				test_mtu                => $test_mtu, 
+			}});
+		}
+		else
+		{
+			$anvil->data->{tested}{$test_mtu} = 'fail';
+			$test_mtu                         = ($test_mtu - ($difference / 2**$i));
+			$test_mtu                         = round_to_100($anvil, $test_mtu);
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				"tested::$test_mtu" => $anvil->data->{tested}{$test_mtu},
+				test_mtu            => $test_mtu, 
+			}});
+		}
+	}
+	print "Found the highest usable MTU, rounded down to an even 100, is: [".$anvil->data->{sys}{highest_good_mtu}."].\n";
+	
+	return ($anvil->data->{sys}{highest_good_mtu});
+}
+
+sub set_mtu_and_ping
+{
+	my ($anvil, $test_mtu, $repeat) = @_;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		test_mtu => $test_mtu, 
+		repeat   => $repeat, 
+	}});
+	
+	my $ok = 0;
+	
+	# Change the MTUs, remote first.
+	my $new_remote_mtu = alter_mtu($anvil, "remote", $test_mtu);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { new_remote_mtu => $new_remote_mtu }});
+
+	print " - Remote: [".$anvil->data->{sys}{target_interface}{device}."] now set with MTU: [".$new_remote_mtu."]\n";
+	if ($test_mtu ne $new_remote_mtu)
+	{
+		print "Too high.\n";
+		print "[ Note ] - I was unable to bump the MTU up to: [".$test_mtu."] on remote.\n";
+		print "[ Note ] - Still at an MTU of: [".$new_remote_mtu."].\n";
+		return($ok);
+	}
+	my $new_local_mtu = alter_mtu($anvil, "local", $test_mtu);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { new_local_mtu => $new_local_mtu }});
+
+	print " - Local:  [".$anvil->data->{sys}{target_interface}{device}."] now set with MTU: [".$new_local_mtu."]\n";
+	if ($test_mtu ne $new_local_mtu)
+	{
+		print "Too high.\n";
+		print "[ Note ] - I was unable to bump the MTU up to: [".$test_mtu."] on remote.\n";
+		print "[ Note ] - Still at an MTU of: [".$new_remote_mtu."].\n";
+		return($ok);
+	}
+	
+	my $ping_size = $test_mtu - $anvil->data->{sys}{icmp_overhead};
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { ping_size => $ping_size }});
+	print " - Pinging: [".$anvil->data->{switches}{target}."] with a single packet of: [".$ping_size."] bytes.\n";
+	
+	my $success = ping_remote($anvil, $ping_size);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { success => $success }});
+	if ($success)
+	{
+		$ok                             = 1;
+		$anvil->data->{sys}{fail_count} = 0;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			ok                => $ok,
+			"sys::fail_count" => $anvil->data->{sys}{fail_count},
+		}});
+		print " - ICMP payload delivered in one packet, MTU appears valid!\n";
+		print "OK!\n";
+	}
+	else
+	{
+		$anvil->data->{sys}{fail_count}++;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			"sys::fail_count" => $anvil->data->{sys}{fail_count},
+		}});
+		if ($anvil->data->{sys}{fail_count} > $anvil->data->{sys}{fail_limit})
+		{
+			print "Failed!\n";
+			print "[ Warning ] - ICMP payload delivery failed, MTU appears invalid!\n";
+			return($ok);
+		}
+		else
+		{
+			print "Failed! [".$anvil->data->{sys}{fail_count}."/".$anvil->data->{sys}{fail_limit}."]\n";
+			print "[ Warning ] - ICMP payload delivery failed!\n";
+			print "[ Note ]    - Failure count below limit: [".$anvil->data->{sys}{fail_count}."/".$anvil->data->{sys}{fail_limit}."].\n";
+			print "[ Note ]    - Retrying in one second in case of transient network traffic.\n";
+			sleep 1;
+			$ok = set_mtu_and_ping($anvil, $test_mtu, 1);
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { ok => $ok }});
+		}
+	}
+	
+	return($ok);
+}
+
+sub ping_remote
+{
+	my ($anvil, $size) = @_;
+	
+	# Do a single, non-fragmenting ping.
+	my $success    = 0;
+	my $shell_call = $anvil->data->{path}{exe}{ping}." ".$anvil->data->{switches}{target}." -w 1 -M do -c 1 -s ".$size;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+	
+	my ($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		output      => $output,
+		return_code => $return_code, 
+	}});
+	foreach my $line (split/\n/, $output)
+	{
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { line => $line }});
+		if ($line =~ /0% packet loss/)
+		{
+			$success = 1;
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { success => $success }});
+			last;
+		}
+	}
+
+	return ($success);
+}
+
+sub alter_mtu
+{
+	my ($anvil, $where, $mtu) = @_;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		where => $where, 
+		mtu   => $mtu, 
+	}});
+	
+	my $hash_key = $where eq "local" ? "source_interface" : "target_interface";
+	my $device   = $anvil->data->{sys}{$hash_key}{device};
+	my $name     = $anvil->data->{sys}{$hash_key}{name} ? $anvil->data->{sys}{$hash_key}{name} : $anvil->data->{sys}{$hash_key}{device};
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		hash_key => $hash_key,
+		device   => $device, 
+		name     => $name, 
+	}});
+	
+	my $network = "";
+	if ($device =~ /^(.*?n\d+)_/)
+	{
+		$network = $1;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { network => $network }});
+	}
+	
+	# Alter the MTU. To handle bonds and bridges, we'll loop through all devices with the target device's prefix (if applicable).
+	my $new_mtu = "";
+	if ($where eq "remote")
+	{
+		# Remove call.
+		if ($network)
+		{
+			# Call once for all interfaces.
+			my $host = $anvil->data->{switches}{target};
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { host => $host }});
+			foreach my $interface (sort {$a cmp $b} keys %{$anvil->data->{network}{$host}{interface}})
+			{
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { interface => $interface }});
+				next if $interface !~ /^${network}_/;
+				
+				my $name       = $anvil->data->{network}{$host}{interface}{$interface}{variable}{NAME} ? $anvil->data->{network}{$host}{interface}{$interface}{variable}{NAME} : $interface;
+				my $shell_call = $anvil->data->{path}{exe}{nmcli}." connection modify \"".$name."\" 802-3-ethernet.mtu ".$mtu." && ".$anvil->data->{path}{exe}{nmcli}." connection up \"".$name."\"";
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+				
+				my ($output, $error, $return_code) = $anvil->Remote->call({
+					target     => $anvil->data->{switches}{target}, 
+					password   => $anvil->data->{switches}{password},
+					shell_call => $shell_call,
+				});
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					output      => $output, 
+					error       => $error, 
+					return_code => $return_code,
+				}});
+			}
+		}
+		else
+		{
+			my $shell_call = $anvil->data->{path}{exe}{nmcli}." connection modify \"".$name."\" 802-3-ethernet.mtu ".$mtu." && ".$anvil->data->{path}{exe}{nmcli}." connection up \"".$name."\"";
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+			
+			my ($output, $error, $return_code) = $anvil->Remote->call({
+				target     => $anvil->data->{switches}{target}, 
+				password   => $anvil->data->{switches}{password},
+				shell_call => $shell_call,
+			});
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				output      => $output, 
+				error       => $error, 
+				return_code => $return_code,
+			}});
+		}
+		
+		# Check that the MTU is now what we want
+		my $shell_call = $anvil->data->{path}{exe}{ip}." addr list ".$device;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+		
+		my ($output, $error, $return_code) = $anvil->Remote->call({
+			target     => $anvil->data->{switches}{target}, 
+			password   => $anvil->data->{switches}{password},
+			shell_call => $shell_call,
+		});
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			output      => $output, 
+			error       => $error, 
+			return_code => $return_code,
+		}});
+		
+		foreach my $line (split/\n/, $output)
+		{
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { line => $line }});
+			if ($line =~ /mtu (\d+) /)
+			{
+				$new_mtu = $1;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { new_mtu => $new_mtu }});
+				last;
+			}
+		}
+	}
+	else
+	{
+		# Local call
+		if ($network)
+		{
+			# Call once for all interfaces.
+			my $host = $anvil->Get->short_host_name();
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { host => $host }});
+			foreach my $interface (sort {$a cmp $b} keys %{$anvil->data->{network}{$host}{interface}})
+			{
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { interface => $interface }});
+				next if $interface !~ /^${network}_/;
+				
+				my $name       = $anvil->data->{network}{$host}{interface}{$interface}{variable}{NAME} ? $anvil->data->{network}{$host}{interface}{$interface}{variable}{NAME} : $interface;
+				my $shell_call = $anvil->data->{path}{exe}{nmcli}." connection modify \"".$name."\" 802-3-ethernet.mtu ".$mtu." && ".$anvil->data->{path}{exe}{nmcli}." connection up \"".$name."\"";
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+				
+				my ($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					output      => $output,
+					return_code => $return_code, 
+				}});
+			}
+		}
+		else
+		{
+			my $shell_call = $anvil->data->{path}{exe}{nmcli}." connection modify \"".$name."\" 802-3-ethernet.mtu ".$mtu." && ".$anvil->data->{path}{exe}{nmcli}." connection up \"".$name."\"";
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+			
+			my ($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+				output      => $output,
+				return_code => $return_code, 
+			}});
+		}
+		
+		my $shell_call = $anvil->data->{path}{exe}{ip}." addr list ".$device;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+		
+		my ($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			output      => $output,
+			return_code => $return_code, 
+		}});
+		
+		foreach my $line (split/\n/, $output)
+		{
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { line => $line }});
+			if ($line =~ /mtu (\d+) /)
+			{
+				$new_mtu = $1;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { new_mtu => $new_mtu }});
+				last;
+			}
+		}
+	}
+	
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		new_mtu => $new_mtu,
+		mtu     => $mtu, 
+	}});
+	if ($new_mtu ne $mtu)
+	{
+		# Failed.
+		print "[ Warning ] - Failed to set the ".$where." device: [".$device."] to have an MTU of: [".$mtu."]\n";
+		print "[ Warning ] - Detected current MTU as: [".$new_mtu."]\n";
+	}
+	
+	return ($new_mtu);
+}
+
+sub round_to_100
+{
+	my ($anvil, $number) = @_;
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { number => $number }});
+	
+	$number = sprintf("%.0f", $number);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { number => $number }});
+	
+	my $diff = ($number % 100);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { diff => $diff }});
+	if ($diff >= 50)
+	{
+		$number += (100 - $diff);
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { number => $number }});
+	}
+	else
+	{
+		$number -= $diff;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { number => $number }});
+	}
+	
+	return ($number);
+}
+
+sub checks
+{
+	my ($anvil) = @_;
+	
+	if ((not $anvil->data->{switches}{source}) or (not $anvil->data->{switches}{target}))
+	{
+		print "Usage: ".$THIS_FILE." --source <local ip> --target <peer IP>\n";
+		$anvil->nice_exit({exit_code => 1});
+	}
+
+	if (not $anvil->Validate->ip({ip => $anvil->data->{switches}{source}}))
+	{
+		print "The source IP: [".$anvil->data->{switches}{source}."] does not appear to be valid.\n";
+		$anvil->nice_exit({exit_code => 1});
+	}
+	
+	if (not $anvil->Validate->ip({ip => $anvil->data->{switches}{target}}))
+	{
+		print "The target IP: [".$anvil->data->{switches}{target}."] does not appear to be valid.\n";
+		$anvil->nice_exit({exit_code => 1});
+	}
+	
+	my $access = $anvil->Remote->test_access({
+		target   => $anvil->data->{switches}{target}, 
+		password => $anvil->data->{switches}{password},
+	});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { access => $access }});
+	if ($access)
+	{
+		if (not $anvil->data->{switches}{y})
+		{
+			print "[ OK ]      - Access to: [".$anvil->data->{switches}{target}."] confirmed.\n";
+		}
+	}
+	else
+	{
+		if ($anvil->data->{switches}{password})
+		{
+			print "Failed to log into the target: [".$anvil->data->{switches}{target}."]. Was the password correct?\n";
+		}
+		else
+		{
+			print "Failed to log into the target: [".$anvil->data->{switches}{target}."]. If passwordless access is not configured, you can set the password with '--passord <secret>'.\n";
+		}
+		$anvil->nice_exit({exit_code => 1});
+	}
+	
+	if (($anvil->data->{switches}{'max-mtu'}) && (($anvil->data->{switches}{'max-mtu'} =~ /\D/) or ($anvil->data->{switches}{'max-mtu'} < 1500)))
+	{
+		print "The maximum MTU size: [".$anvil->data->{switches}{'max-mtu'}."] is invalid. It must be a whole number greater than 1500.\n";
+		$anvil->nice_exit({exit_code => 1});
+	}
+	
+	# Make sure 'iperf3' is installed on both machines.
+	if (not -e $anvil->data->{path}{exe}{iperf3})
+	{
+		print "It appears that 'iperf3' is not installed on this system.\n";
+		$anvil->nice_exit({exit_code => 1});
+	}
+	my $shell_call = "if [ -e '".$anvil->data->{path}{exe}{iperf3}."' ]; then echo installed; else echo missing; fi";
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+	my ($output, $error, $return_code) = $anvil->Remote->call({
+		target     => $anvil->data->{switches}{target}, 
+		password   => $anvil->data->{switches}{password},
+		shell_call => $shell_call,
+	});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		output      => $output, 
+		error       => $error, 
+		return_code => $return_code,
+	}});
+	if ($output ne "installed")
+	{
+		print "It appears that 'iperf3' is not installed on this target.\n";
+		$anvil->nice_exit({exit_code => 1});
+	}
+	if (not $anvil->data->{switches}{y})
+	{
+		print "[ OK ]      - Both source and target have 'iperf3' installed'\n";
+	}
+	
+	# Get the device name of the interfaces with the IPs.
+	my $host_name = $anvil->Get->short_host_name();
+	my $target_ip = $anvil->data->{switches}{target};
+	$anvil->Network->get_ips({target => $host_name});
+	$anvil->Network->get_ips({
+		target   => $target_ip,
+		password => $anvil->data->{switches}{password}, 
+	});
+	$anvil->data->{sys}{source_interface}{device} = "";
+	$anvil->data->{sys}{source_interface}{name}   = "";
+	$anvil->data->{sys}{target_interface}{device} = "";
+	$anvil->data->{sys}{target_interface}{name}   = "";
+	foreach my $host ($host_name, $target_ip)
+	{
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { host => $host }});
+		foreach my $interface (sort {$a cmp $b} keys %{$anvil->data->{network}{$host}{interface}})
+		{
+			my $this_ip = $anvil->data->{network}{$host}{interface}{$interface}{ip};
+			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { this_ip => $this_ip }});
+			if ($this_ip eq $anvil->data->{switches}{source})
+			{
+				$anvil->data->{sys}{source_interface}{device} = $interface;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					"sys::source_interface::device" => $anvil->data->{sys}{source_interface}{device},
+				}});
+				
+				if (exists $anvil->data->{network}{$host}{interface}{$interface}{variable}{NAME})
+				{
+					$anvil->data->{sys}{source_interface}{name} = $anvil->data->{network}{$host}{interface}{$interface}{variable}{NAME};
+					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+						"sys::source_interface::name" => $anvil->data->{sys}{source_interface}{name},
+					}});
+				}
+				else
+				{
+					$anvil->data->{sys}{source_interface}{name} = $interface;
+					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+						"sys::source_interface::name" => $anvil->data->{sys}{source_interface}{name},
+					}});
+				}
+			}
+			elsif ($this_ip eq $anvil->data->{switches}{target})
+			{
+				$anvil->data->{sys}{target_interface}{device} = $interface;
+				$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+					"sys::target_interface::device" => $anvil->data->{sys}{target_interface}{device},
+				}});
+				
+				if (exists $anvil->data->{network}{$host}{interface}{$interface}{variable}{NAME})
+				{
+					$anvil->data->{sys}{target_interface}{name} = $anvil->data->{network}{$host}{interface}{$interface}{variable}{NAME};
+					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+						"sys::target_interface::name" => $anvil->data->{sys}{target_interface}{name},
+					}});
+				}
+				else
+				{
+					$anvil->data->{sys}{target_interface}{name} = $interface;
+					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+						"sys::target_interface::name" => $anvil->data->{sys}{target_interface}{name},
+					}});
+				}
+			}
+		}
+	}
+	if (not $anvil->data->{sys}{source_interface}{name})
+	{
+		print "Unable to find the local network interface with the IP: [".$anvil->data->{switches}{source}."].\n";
+		$anvil->nice_exit({exit_code => 1});
+	}
+	if (not $anvil->data->{sys}{target_interface}{name})
+	{
+		print "Unable to find the target's network interface with the IP: [".$anvil->data->{switches}{target}."].\n";
+		$anvil->nice_exit({exit_code => 1});
+	}
+	
+	# Ask if we can proceed.
+	if (not $anvil->data->{switches}{y})
+	{
+		print "=============================================================================================================
+[ Warning ] - This test will alter the MTU sizes of the network interfaces. In some cases, this could cause 
+              the network to stop working. Any applications that rely on the network could fail (like a 
+              cluster). Do you have direct access to this machine and the target machine to reset the MTU if
+              needed? This test can take up to half an hour to run!
+=============================================================================================================
+[ Note ]    - You can skip this prompt by using '--y'.
+[ Note ]    - You can set the maximum MTU to test with '--max-mtu <bytes>'.
+            - Are you ready to proceed? [n/Y]
+";
+		my $answer = <STDIN>;
+		chomp $answer;
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { answer => $answer }});
+
+		if ((lc($answer) ne "y") && (lc($answer) ne "yes"))
+		{
+			print "Aborting.\n";
+			$anvil->nice_exit({exit_code => 0});
+		}
+	}
+	
+	return(0);
+}

--- a/tools/anvil-provision-server
+++ b/tools/anvil-provision-server
@@ -857,6 +857,17 @@ sub startup_resource
 					}
 					$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, key => "log_0580", variables => { resource => $anvil->data->{job}{server_name} }});
 					
+					# Make it secondary again. This is needed as it won't auto-demote 
+					# otherwise.
+					$shell_call = $anvil->data->{path}{exe}{drbdadm}." secondary ".$anvil->data->{job}{server_name};
+					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});
+					
+					($output, $return_code) = $anvil->System->call({shell_call => $shell_call});
+					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+						output      => $output,
+						return_code => $return_code,
+					}});
+					
 					# set the fencing back
 					$shell_call = $anvil->data->{path}{exe}{drbdadm}." adjust ".$anvil->data->{job}{server_name};
 					$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { shell_call => $shell_call }});

--- a/tools/scancore
+++ b/tools/scancore
@@ -68,9 +68,8 @@ $anvil->data->{scancore} = {
 $anvil->Storage->read_config();
 
 # Read switches
-$anvil->data->{switches}{purge}      = "";
-$anvil->data->{switches}{'run-once'} = "";
-$anvil->Get->switches;
+$anvil->Get->switches({list => ["purge", "run-once"], man => $THIS_FILE});
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
 $anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, key => "log_0115", variables => { program => $THIS_FILE }});
 
 # If purging, also set 'run-once'.

--- a/tools/striker-parse-oui
+++ b/tools/striker-parse-oui
@@ -3,6 +3,9 @@
 # This periodically reads in http://standards-oui.ieee.org/oui/oui.txt, if possible, and parses it to update/
 # populate the oui database table.
 # 
+# NOTE: 
+# - Disabled for now. Move the OUI data to a flat file and change lookup to read the file. Too big for the DB / resync.
+# 
 # TODO: 
 # 
 
@@ -46,6 +49,14 @@ update_progress($anvil, 1, "log_0239,!!job-uuid!".$anvil->data->{switches}{'job-
 $anvil->data->{progress} = 1;
 
 check_if_time($anvil);
+
+### NOTE: Disabled 
+print $anvil->Words->string({key => "message_0291"})."\n";
+update_progress($anvil, 100, "message_0291");
+$anvil->nice_exit({exit_code => 0});
+
+
+
 
 my $oui_file = $anvil->Get->users_home({debug => 3})."/oui.txt";
 $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { oui_file => $oui_file }});

--- a/tools/striker-prep-database
+++ b/tools/striker-prep-database
@@ -13,6 +13,10 @@
 # 
 # TODO: Much of this logic is duplicated in Database->configure_pgsql(), we should remove this tool entirely 
 #       and use that.
+# NOTE: Now disabled, to be reomved.
+
+
+exit(0);
 
 use strict;
 use warnings;


### PR DESCRIPTION
…en reconfiguring the network, the request to set a job to reboot would fail because the connections to all Strikers could be lost, causing Database->_test_access() would error out, blocking the reboot. When restarted, the network would not be changed, so no reboot would be requested, leaving the machine in an innaccesible state.

* Updated anvil-boot-server when called with '--all' to honour boot ordering, delays and condtions.
* Updated Database->get_servers() to collect the server's XML as well as data from the 'servers' table.
* Updated anvil-provision-server to make a new DRBD resource 'secondary' after forcing it to primary to begin the initial sync.

Signed-off-by: Digimer <digimer@alteeve.ca>