### PR TITLE
* Fixed a bug where deleting ports from a fence device in an Install …

### DIFF
--- a/man/anvil-manage-server.8
+++ b/man/anvil-manage-server.8
@@ -1,0 +1,75 @@
+.\" Manpage for the Alteeve! anvil-manage-server tool
+.\" Contact mkelly@alteeve.com to report issues, concerns or suggestions.
+.TH anvil-manage-server "8" "October 19 2022" "Anvil! Intelligent Availability™ Platform"
+.SH NAME
+anvil-manage-server \- Tool used to manage a server running on an Anvil! cluster.
+.SH SYNOPSIS
+.B anvil-manage-server 
+\fI\,<command> \/\fR[\fI\,options\/\fR]
+.SH DESCRIPTION
+anvil-manage-server \- This tool allow the management of a server's hardware.
+.TP
+.SH OPTIONS
+.TP
+\-?, \-h, \fB\-\-help\fR
+Show this man page.
+.TP
+\-d, \fB\-\-job-uuid\fR
+This is the jobs -> job_uuid of the job to run, if it exists.
+.TP
+\fB\-\-log-secure\fR
+When logging, record sensitive data, like passwords.
+.TP
+\fB\-v\fR, \fB\-vv\fR, \fB\-vvv\fR
+Set the log level for this run to 1, 2 or 3 (higher == more verbose).
+.TP
+.SS "Commands:"
+.TP
+\-k, \fB\-\-anvil\fR <name or uuid>
+If specified, and \fBserver\fR is not specified, this will list the servers running on the Anvil! system currently. If, in the unlikely event that two servers exist on different Anvil! systems but with the same name, this will help identify which server you want to work on.
+.TP
+\-k, \fB\-\-server\fR <name or uuid>
+
+.TP
+\-k, \fB\-\-\fR <uuid>
+
+.TP
+\-k, \fB\-\-\fR <uuid>
+
+.TP
+\-k, \fB\-\-\fR <uuid>
+
+.TP
+\-k, \fB\-\-\fR <uuid>
+
+.TP
+\-k, \fB\-\-\fR <uuid>
+
+.TP
+\-k, \fB\-\-\fR <uuid>
+
+.TP
+\-k, \fB\-\-\fR <uuid>
+
+.TP
+\-k, \fB\-\-\fR <uuid>
+
+.TP
+\-k, \fB\-\-\fR <uuid>
+
+$anvil->data->{switches}{boot}        = "";	# This is a comma-separated list of ordered boot devices
+$anvil->data->{switches}{cores}       = "";	# This sets the server to use this number of CPU cores.
+$anvil->data->{switches}{drive}       = "";	# drive being modified (insert/eject ISO, growing drive)
+$anvil->data->{switches}{eject}       = "";	# This will eject whatever ISO (if any) in the '--drive'. 
+$anvil->data->{switches}{'expand-to'} = "";	# When the drive is a disk (backed by a DRBD resource), this is the new desired size to grow to.
+$anvil->data->{switches}{insert}      = "";	# This is the ISO to insert into the --drive
+$anvil->data->{switches}{'job-uuid'}  = "";
+$anvil->data->{switches}{ram}         = "";	# This is the amount of RAM to set the server to use.
+$anvil->data->{switches}{server}      = "";	# server name or uuid
+$anvil->data->{switches}{y}           = "";	# Don't prompt for confirmation. Only useful when there isn't a job UUID.
+
+.IP
+.SH AUTHOR
+Written by Madison Kelly, Alteeve staff and the Anvil! project contributors.
+.SH "REPORTING BUGS"
+Report bugs to users@clusterlabs.org

--- a/share/words.xml
+++ b/share/words.xml
@@ -1417,6 +1417,7 @@ Note: This is a permanent action! If you protect this server again later, a full
 		<key name="job_0419">The server: [#!variable!server!#] was found to be running outside the cluster. Asking it to shut down now.</key>
 		<key name="job_0428">The server: [#!variable!server!#] is still running two minutes after asking it to stop. It might have woken up on the first press and ignored the shutdown request (Hi Windows). Pressing the poewr button again.</key>
 		<key name="job_0429">Copying the Long-throw (drbd proxy) license file: [#!variable!file!#] into place.</key>
+		<key name="job_0430">The fence device: [#!variable!device!#] no longer has a port associated with it, will remove it.</key>
 		
 		<!-- Log entries -->
 		<key name="log_0001">Starting: [#!variable!program!#].</key>

--- a/tools/anvil-manage-server
+++ b/tools/anvil-manage-server
@@ -29,31 +29,15 @@ $| = 1;
 
 my $anvil = Anvil::Tools->new();
 
-$anvil->data->{switches}{anvil}       = "";	# This is the Anvil! Name or UUID being worked on.
-$anvil->data->{switches}{boot}        = "";	# This is a comma-separated list of ordered boot devices
-$anvil->data->{switches}{cores}       = "";	# This sets the server to use this number of CPU cores.
-$anvil->data->{switches}{drive}       = "";	# drive being modified (insert/eject ISO, growing drive)
-$anvil->data->{switches}{eject}       = "";	# This will eject whatever ISO (if any) in the '--drive'. 
-$anvil->data->{switches}{'expand-to'} = "";	# When the drive is a disk (backed by a DRBD resource), this is the new desired size to grow to.
-$anvil->data->{switches}{insert}      = "";	# This is the ISO to insert into the --drive
-$anvil->data->{switches}{'job-uuid'}  = "";
-$anvil->data->{switches}{ram}         = "";	# This is the amount of RAM to set the server to use.
-$anvil->data->{switches}{server}      = "";	# server name or uuid
-$anvil->data->{switches}{y}           = "";	# Don't prompt for confirmation. Only useful when there isn't a job UUID.
-$anvil->Get->switches;
-$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, 'print' => 1, level => 1, secure => 0, key => "log_0115", variables => { program => $THIS_FILE }});
-$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
-	'switches::boot'      => $anvil->data->{switches}{boot},
-	'switches::cores'     => $anvil->data->{switches}{cores},
-	'switches::drive'     => $anvil->data->{switches}{drive},
-	'switches::eject'     => $anvil->data->{switches}{eject},
-	'switches::expand-to' => $anvil->data->{switches}{'expand-to'},
-	'switches::insert'    => $anvil->data->{switches}{insert}, 
-	'switches::job-uuid'  => $anvil->data->{switches}{'job-uuid'},
-	'switches::ram'       => $anvil->data->{switches}{ram}, 
-	'switches::server'    => $anvil->data->{switches}{server}, 
-	'switches::y'         => $anvil->data->{switches}{y}, 
-}});
+### TODO: Remove this before final release
+$anvil->Log->level({set => 2});
+$anvil->Log->secure({set => 1});
+##########################################
+
+# Read switches (target ([user@]host[:port]) and the file with the target's password.
+$anvil->Get->switches({list => ["anvil", "boot", "cores", "drive", "eject", "expand-to", "insert", "ram", "server", "y"], man => $THIS_FILE});
+$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});
+$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0115", variables => { program => $THIS_FILE }});
 
 # Connect to the database(s). If we have no connections, we'll proceed anyway as one of the 'run_once' tasks
 # is to setup the database server.
@@ -94,12 +78,16 @@ if ($anvil->data->{switches}{'job-uuid'})
 }
 else
 {
+	process_interactive($anvil);
+	
+	
+	### TODO: Old way
 	# Interactive!
-	$anvil->data->{new_config}{cpu}{sockets} = "";
-	$anvil->data->{new_config}{cpu}{cores}   = "";
-	$anvil->data->{new_config}{ram}{'bytes'} = "";
-	$anvil->data->{old_config}{ram}{'bytes'} = "";
-	interactive_question($anvil);
+# 	$anvil->data->{new_config}{cpu}{sockets} = "";
+# 	$anvil->data->{new_config}{cpu}{cores}   = "";
+# 	$anvil->data->{new_config}{ram}{'bytes'} = "";
+# 	$anvil->data->{old_config}{ram}{'bytes'} = "";
+# 	interactive_question($anvil);
 }
 
 $anvil->nice_exit({exit_code => 0});
@@ -108,6 +96,81 @@ $anvil->nice_exit({exit_code => 0});
 #############################################################################################################
 # Functions                                                                                                 #
 #############################################################################################################
+
+sub process_interactive
+{
+	my ($anvil) = @_;
+	
+	# Preset values.
+	$anvil->data->{target_server}{anvil_uuid}            = "" if not exists $anvil->data->{target_server}{anvil_uuid};
+	$anvil->data->{target_server}{anvil_name}            = "" if not exists $anvil->data->{target_server}{anvil_uuid};
+	$anvil->data->{target_server}{server_uuid}           = "" if not exists $anvil->data->{target_server}{anvil_uuid};
+	$anvil->data->{target_server}{server_uuid}           = "" if not exists $anvil->data->{target_server}{anvil_uuid};
+	$anvil->data->{target_server}{server_state}          = "" if not exists $anvil->data->{target_server}{server_state};
+	$anvil->data->{target_server}{anvil_description}     = "" if not exists $anvil->data->{target_server}{anvil_description};
+	$anvil->data->{target_server}{anvil_node1_host_uuid} = "" if not exists $anvil->data->{target_server}{anvil_node1_host_uuid};
+	$anvil->data->{target_server}{anvil_node1_host_name} = "" if not exists $anvil->data->{target_server}{anvil_node1_host_name};
+	$anvil->data->{target_server}{anvil_node2_host_uuid} = "" if not exists $anvil->data->{target_server}{anvil_node2_host_uuid};
+	$anvil->data->{target_server}{anvil_node2_host_name} = "" if not exists $anvil->data->{target_server}{anvil_node2_host_name};
+	$anvil->data->{target_server}{anvil_dr1_host_uuid}   = "" if not exists $anvil->data->{target_server}{anvil_dr1_host_uuid};
+	$anvil->data->{target_server}{anvil_dr1_host_name}   = "" if not exists $anvil->data->{target_server}{anvil_dr1_host_name};
+	
+	
+	$anvil->data->{new_config}{cpu}{sockets} = "";
+	$anvil->data->{new_config}{cpu}{cores}   = "";
+	$anvil->data->{new_config}{ram}{'bytes'} = "";
+	
+	$anvil->data->{old_config}{ram}{'bytes'} = "";
+	
+	# Did they specify an Anvil! system?
+	if ($anvil->data->{switches}{anvil})
+	{
+		$anvil->Get->anvil_from_switch({anvil => $anvil->data->{switches}{anvil}});
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			"switches::anvil_name" => $anvil->data->{switches}{anvil_name},
+			"switches::anvil_uuid" => $anvil->data->{switches}{anvil_uuid},
+		}});
+	}
+	
+	# Did they specify a server?
+	if ($anvil->data->{switches}{server})
+	{
+		$anvil->Get->server_from_switch({server => $anvil->data->{switches}{server}});
+		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+			"switches::anvil_name" => $anvil->data->{switches}{anvil_name},
+			"switches::anvil_uuid" => $anvil->data->{switches}{anvil_uuid},
+		}});
+	}
+	
+	if (not $anvil->data->{target_server}{anvil_uuid})
+	{
+	}
+	
+	return(0);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### NOTE: Old functions, likely to be removed ###
 
 sub run_jobs
 {

--- a/tools/striker-initialize-host
+++ b/tools/striker-initialize-host
@@ -30,11 +30,6 @@ $| = 1;
 
 my $anvil = Anvil::Tools->new();
 
-### TODO: Remove this before final release
-$anvil->Log->level({set => 2});
-$anvil->Log->secure({set => 1});
-##########################################
-
 # Read switches (target ([user@]host[:port]) and the file with the target's password.
 $anvil->Get->switches({list => ["enterprise-uuid", "host-ip-address", "password", "rh-password", "rh-user", "ssh-port", "target", "type"], man => $THIS_FILE});
 $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => $anvil->data->{switches}});


### PR DESCRIPTION
…Manifest would not cause the fence methods to be removed from the associated cluster.

* Created Get->anvil_from_switch and Get->server_from_switch() (both need testing) that takes a string that could be either a name or UUID, figures out which it is, finds the entry in the DB and started the X_uuid and X_name switch variables.
* Started work on a second attempt at anvil-manage-server.

Signed-off-by: Digimer <digimer@alteeve.ca>