### PR TITLE
Override anvil_resources::<anvil_uuid>::ram::reserved by anvil.conf entry

### DIFF
--- a/Anvil/Tools/Get.pm
+++ b/Anvil/Tools/Get.pm
@@ -717,26 +717,28 @@ ORDER BY
 		}});
 	}
 
-    # Check if the reserved RAM is overriden by the config
-    my $ram_reserved = $anvil->data->{anvil_resources}{ram}{reserved};
-    if (not $ram_reserved or $ram_reserved < 0 or $ram_reserved > $anvil->data->{anvil_resources}{$anvil_uuid}{ram}{hardware})
-    {
-        $ram_reserved = 0;
-    }
+	# Check if the reserved RAM is overriden by the config
+	my $ram_reserved = $anvil->Convert->human_readable_to_bytes({
+		base2 => 1,
+		size  => $anvil->data->{anvil_resources}{ram}{reserved}, 
+	});
+	if (($ram_reserved eq "!!error!!") or 
+		(not $ram_reserved)            or 
+	    ($ram_reserved < (2**30))      or 
+	    ($ram_reserved > $anvil->data->{anvil_resources}{$anvil_uuid}{ram}{hardware}))
+	{
+		# The reserved RAM is invalid, so reset it.
+		$ram_reserved = 0;
+	}
 
-    $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
-        "anvil_resources::ram::reserved" => $ram_reserved." (".$anvil->Convert->bytes_to_human_readable({'bytes' => $ram_reserved}).")",
-    }});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
+		"anvil_resources::ram::reserved" => $ram_reserved." (".$anvil->Convert->bytes_to_human_readable({'bytes' => $ram_reserved}).")",
+	}});
 
 	# Take 4 GiB or what was provided by the config off the available RAM for the host
-    $anvil->data->{anvil_resources}{$anvil_uuid}{ram}{reserved}   = $ram_reserved ? $ram_reserved : (4*(2**30)); # Reserve 4 GiB by default or what's set in the config file.
+	$anvil->data->{anvil_resources}{$anvil_uuid}{ram}{reserved}   = $ram_reserved ? $ram_reserved : (4*(2**30)); # Reserve 4 GiB by default or what's set in the config file.
 	$anvil->data->{anvil_resources}{$anvil_uuid}{ram}{available} -= $anvil->data->{anvil_resources}{$anvil_uuid}{ram}{reserved};
 	$anvil->data->{anvil_resources}{$anvil_uuid}{ram}{available} -= $anvil->data->{anvil_resources}{$anvil_uuid}{ram}{allocated};
-
-    if ($anvil->data->{anvil_resources}{$anvil_uuid}{ram}{available} < 0)
-    {
-        $anvil->data->{anvil_resources}{$anvil_uuid}{ram}{available} = 0;
-    }
 
 	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => $debug, list => { 
 		"anvil_resources::${anvil_uuid}::ram::allocated" => $anvil->data->{anvil_resources}{$anvil_uuid}{ram}{allocated}." (".$anvil->Convert->bytes_to_human_readable({'bytes' => $anvil->data->{anvil_resources}{$anvil_uuid}{ram}{allocated}}).")",


### PR DESCRIPTION
Maybe that will do for issue fix #263 ?

Some observations from https://github.com/ClusterLabs/anvil/blob/6a8dd07f3642e2a2cc83840d0f5691bcbab002de/tools/anvil-provision-server#L1758-L1763
Why is the amount of RAM compared to `(1**20)` which is 1? Is it on purpose?