### PR TITLE
Disable web VNC, screenshot pieces to avoid libvirt deadlock

### DIFF
--- a/libvirt/hooks/qemu.d/ws
+++ b/libvirt/hooks/qemu.d/ws
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# TODO: re-enable after the possible libvirt deadlock is fixed.
+exit 0
+
 {
 	echo "wsargs=$@"
 

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -554,7 +554,8 @@ sub handle_periodic_tasks
 		# Check if anything is needed to be done in /mnt/shared.
 		check_incoming($anvil);
 
-		do_non_striker_tasks($anvil);
+		# TODO: resolve the possible libvirt deadlock and re-enable screenshot fetching.
+		# do_non_striker_tasks($anvil);
 
 		# Check for stale db_in_use states.
 		check_db_in_use_states($anvil);


### PR DESCRIPTION
Until a proper fix is available (including allow users to interact with VMs ASAP post `virt-install`), disable anything web UI related that can cause `virt-install` to fail.