### PR TITLE
Web UI: pass an explicit value for query params

### DIFF
--- a/striker-ui/components/Display/Preview.tsx
+++ b/striker-ui/components/Display/Preview.tsx
@@ -121,7 +121,7 @@ const Preview: FC<PreviewProps> = ({
       (async () => {
         try {
           const response = await fetch(
-            `${API_BASE_URL}/server/${serverUUID}?ss`,
+            `${API_BASE_URL}/server/${serverUUID}?ss=1`,
             {
               method: 'GET',
               headers: {

--- a/striker-ui/pages/index.tsx
+++ b/striker-ui/pages/index.tsx
@@ -154,7 +154,7 @@ const Dashboard: FC = () => {
           };
 
           fetchJSON<{ screenshot: string }>(
-            `${API_BASE_URL}/server/${serverUUID}?ss`,
+            `${API_BASE_URL}/server/${serverUUID}?ss=1`,
           )
             .then(({ screenshot }) => {
               item.screenshot = screenshot;


### PR DESCRIPTION
The query param to specify whether to take screenshot is present but not set to a value.

**This PR is not ready until #402 is merged, and source rebuilt.**