### PR TITLE
Web UI: add close button to the add peer dialog

### DIFF
--- a/striker-ui/components/Display/Preview.tsx
+++ b/striker-ui/components/Display/Preview.tsx
@@ -121,7 +121,7 @@ const Preview: FC<PreviewProps> = ({
       (async () => {
         try {
           const response = await fetch(
-            `${API_BASE_URL}/server/${serverUUID}?ss`,
+            `${API_BASE_URL}/server/${serverUUID}?ss=1`,
             {
               method: 'GET',
               headers: {

--- a/striker-ui/components/StrikerConfig/AddPeerDialog.tsx
+++ b/striker-ui/components/StrikerConfig/AddPeerDialog.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, useCallback, useMemo, useRef, useState } from 'react';
+import {
+  MutableRefObject,
+  forwardRef,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import INPUT_TYPES from '../../lib/consts/INPUT_TYPES';
 
@@ -11,6 +18,7 @@ import ConfirmDialog from '../ConfirmDialog';
 import FlexBox from '../FlexBox';
 import Grid from '../Grid';
 import handleAPIError from '../../lib/handleAPIError';
+import IconButton from '../IconButton';
 import InputWithRef, { InputForwardedRefContent } from '../InputWithRef';
 import { Message } from '../MessageBox';
 import MessageGroup, { MessageGroupForwardedRefContent } from '../MessageGroup';
@@ -19,7 +27,7 @@ import {
   buildIPAddressTestBatch,
   buildPeacefulStringTestBatch,
 } from '../../lib/test_input';
-import { BodyText } from '../Text';
+import { BodyText, HeaderText } from '../Text';
 import useProtect from '../../hooks/useProtect';
 import useProtectedState from '../../hooks/useProtectedState';
 
@@ -305,7 +313,22 @@ const AddPeerDialog = forwardRef<
       }}
       proceedButtonProps={{ disabled: isFormInvalid }}
       ref={ref}
-      titleText="Add a peer"
+      titleText={
+        <>
+          <HeaderText>Add a peer</HeaderText>
+          <IconButton
+            mapPreset="close"
+            onClick={() => {
+              if (ref && 'current' in ref) {
+                (
+                  ref as MutableRefObject<ConfirmDialogForwardedRefContent>
+                ).current.setOpen?.call(null, false);
+              }
+            }}
+            variant="redcontained"
+          />
+        </>
+      }
     />
   );
 });

--- a/striker-ui/pages/index.tsx
+++ b/striker-ui/pages/index.tsx
@@ -154,7 +154,7 @@ const Dashboard: FC = () => {
           };
 
           fetchJSON<{ screenshot: string }>(
-            `${API_BASE_URL}/server/${serverUUID}?ss`,
+            `${API_BASE_URL}/server/${serverUUID}?ss=1`,
           )
             .then(({ screenshot }) => {
               item.screenshot = screenshot;


### PR DESCRIPTION
This PR provides a more intuitive way to close the add peer dialog.

**This PR is not ready until #416, #402 are merged, and source is rebuilt.**

Closes #410