### PR TITLE
Working on a bug where broken manifests are saved.

### DIFF
--- a/Anvil/Tools/Striker.pm
+++ b/Anvil/Tools/Striker.pm
@@ -300,7 +300,37 @@ sub check_httpd_conf
 
 =head2 generate_manifest
 
-This reads the CGI data coming from the manifest form to generate the manifest XML.
+This reads the CGI data coming from the manifest form to generate the manifest XML. On success, the C<< manifest_uuid >>, and C<< manifest_uuid >> are returned. If there's a problem, C<< !!error!! >> is returned.
+
+Parameters;
+
+=head3 dns (optional)
+
+This is a comma-separated list of DNS servers to use. 
+
+=head3 domain (required)
+
+This is the domain name to use for this Anvil! node.
+
+=head3 manifest_uuid (optional)
+
+This allows updating an existing mannifest, or specifying the manifest UUID to use for the new manifest.
+
+=head3 mtu (optional)
+
+This allows specifying a custome MTU (maximum transmission unit) size. Only use this if you know all network devices support this MTU size!
+
+=head3 ntp (optional)
+
+This allows specifying a custom NTP (network time protocol) server to use to sync the subnode's time against.
+
+=head3 prefix (required)
+
+This is the node's descriptive prefix (usually 1~5 characters). 
+
+=head3 sequence (required)
+
+This is an integer, 1 or higher, indication the node's sequence number.
 
 =cut
 sub generate_manifest
@@ -327,6 +357,24 @@ sub generate_manifest
 		name_prefix     => $name_prefix, 
 		padded_sequence => $padded_sequence, 
 	}});
+	
+	if (not $domain)
+	{
+		# No target...
+		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, priority => "err", key => "log_0020", variables => { method => "Striker->generate_manifest()", parameter => "domain" }});
+		return('!!error!!', '!!error!!');
+	}
+	
+	if (not $name_prefix)
+	{
+		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, priority => "err", key => "log_0020", variables => { method => "Striker->generate_manifest()", parameter => "name_prefix" }});
+		return('!!error!!', '!!error!!');
+	}
+	if (not $padded_sequence)
+	{
+		$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 0, priority => "err", key => "log_0020", variables => { method => "Striker->generate_manifest()", parameter => "padded_sequence" }});
+		return('!!error!!', '!!error!!');
+	}
 	
 	$anvil->Database->get_upses({debug => $debug});
 	$anvil->Database->get_fences({debug => $debug});

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -590,6 +590,9 @@ sub handle_periodic_tasks
 				$anvil->Database->_check_for_duplicates({debug => 2});
 			}
 			
+			# Something is causing broken manifests to be created. Until found, this removes them.
+			check_for_broken_manifests($anvil);
+			
 			# This can take a while, but it's been optimized to minimize how long it takes to 
 			# run. To be safe, we'll still background it.
 			my $shell_call = $anvil->data->{path}{exe}{'striker-get-screenshots'}.$anvil->Log->switches;
@@ -875,6 +878,47 @@ sub handle_periodic_tasks
 			"s1:timing::daily_checks"     => $anvil->data->{timing}{daily_checks},
 			"s2:timing::next_daily_check" => $anvil->data->{timing}{next_daily_check}, 
 		}});
+	}
+	
+	return(0);
+}
+
+### TODO: Find the source of the problem and fix it properly.
+sub check_for_broken_manifests
+{
+	my ($anvil) = @_;
+	
+	my $query =  "
+SELECT 
+    manifest_uuid 
+FROM 
+    manifests 
+WHERE 
+    manifest_name = '-anvil-'
+;";
+	$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 2, key => "log_0124", variables => { query => $query }});
+	my $results = $anvil->Database->query({query => $query, source => $THIS_FILE, line => __LINE__});
+	my $count   = @{$results};
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		results => $results, 
+		count   => $count, 
+	}});
+	if ($count)
+	{
+		foreach my $row (@{$results})
+		{
+			my $manifest_uuid = $row->[0];
+			
+			my $queries = [];
+			push @{$queries}, "DELETE FROM history.manifests WHERE manifest_uuid = ".$anvil->Database->quote($manifest_uuid).";";
+			push @{$queries}, "DELETE FROM manifests WHERE manifest_uuid = ".$anvil->Database->quote($manifest_uuid).";";
+			
+			foreach my $query (sort {$a cmp $b} @{$queries})
+			{
+				$anvil->Log->entry({source => $THIS_FILE, line => __LINE__, level => 1, key => "log_0124", variables => { query => $query }});
+			}
+			$anvil->Database->write({debug => 2, query => $queries, source => $THIS_FILE, line => __LINE__});
+		}
 	}
 	
 	return(0);


### PR DESCRIPTION
* Updated Striker->generate_manifest() to add pod and make the prefix, sequence and domain parameters required.
* Created the check_for_broken_manifests() function for anvil-daemon to detect/remove broken manifests.