### PR TITLE
Anvil tools: patch `anvil-manage-alerts` to ensure alert related records are added correctly

### DIFF
--- a/man/anvil-manage-alerts.8
+++ b/man/anvil-manage-alerts.8
@@ -52,6 +52,8 @@ This is the desired override alert level.
 
 Valid values are: 
 
+0 = "ignore" all alerts
+
 1 = "critical" alerts only
 
 2 = "warning" and critical alerts

--- a/man/anvil-manage-alerts.8
+++ b/man/anvil-manage-alerts.8
@@ -142,11 +142,28 @@ Valid values are:
 
 1 = "critical" alerts only
 
+Critical alerts are events that could lead to imminent service interruption or unexpected loss of redundancy.
+
+These alerts will go to all recipients except for those ignoring the source system entirely.
+
+Alerts at this level should trigger alarm systems for all administrators as well as management who may be impacted by service interruptions.
+
 2 = "warning" and critical alerts
+
+Warning alerts may require attention, such as intentional loss of redundancy caused by load shedding, hardware in pre-failure, loss of input power, temperature anomalies, etc.
+
+Alerts at this level should trigger alarm systems for administrative staff.
 
 3 = "notice", warning and critical alerts
 
-4 = "info"; All alerts. This generates almost constant alerts! 
+Notice alerts are generally safe to ignore, but might provide early warnings of developing issues or insight into system behaviour.
+
+Alerts at this level should not trigger alarm systems. Periodic review is sufficient.
+
+4 = "info"; All alerts. This generates almost constant alerts!
+
+Info alerts are almost always safe to ignore, but may be useful in testing and debugging.
+
 .TP
 \fB\-\-test\fR
 Tells the program to send a test alert at the desired \fB\-\-level\fR. The requested level is required.

--- a/tools/anvil-manage-alerts
+++ b/tools/anvil-manage-alerts
@@ -1817,7 +1817,8 @@ sub check_switches
 		{
 			# normal_password
 			$anvil->data->{sys}{say_new_auth}                      = "name_0001";
-			$anvil->data->{switches}{"mail-server-authentication"} = "normal_password";
+			# TODO: revisit translation(s) after verifying against config syntax
+			# $anvil->data->{switches}{"mail-server-authentication"} = "normal_password";
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 				"sys::say_new_auth"                    => $anvil->data->{sys}{say_new_auth}, 
 				"switches::mail-server-authentication" => $anvil->data->{switches}{"mail-server-authentication"},

--- a/tools/anvil-manage-alerts
+++ b/tools/anvil-manage-alerts
@@ -670,7 +670,7 @@ sub handle_mail_servers
 	{
 		# Do we have what we need?
 		my $problem = 0;
-		foreach my $switch ("mail-server-address", "mail-server-port", "mail-server-username", "mail-server-password", "mail-server-security", "mail-server-authentication", "mail-server-helo-domain")
+		foreach my $switch ("mail-server-address", "mail-server-port", "mail-server-security", "mail-server-authentication", "mail-server-helo-domain")
 		{
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
 				switch              => $switch,


### PR DESCRIPTION
This PR changes the `anvil-manage-alerts` tool and its manpage:
- Make `username` and `password` optional when creating mail server.
- Disable translation from `none` to `normal_password` in mail server authentication.
- Enhance manpage with ignore option for overrides and alert level descriptions.