### PR TITLE
Web UI: add API support for mail config functions

### DIFF
--- a/striker-ui-api/src/lib/consts/SERVER_PATHS.ts
+++ b/striker-ui-api/src/lib/consts/SERVER_PATHS.ts
@@ -34,6 +34,7 @@ const EMPTY_SERVER_PATHS: ServerPath = {
       'anvil-delete-server': {},
       'anvil-get-server-screenshot': {},
       'anvil-join-anvil': {},
+      'anvil-manage-alerts': {},
       'anvil-manage-keys': {},
       'anvil-manage-power': {},
       'anvil-provision-server': {},

--- a/striker-ui-api/src/lib/execManageAlerts.ts
+++ b/striker-ui-api/src/lib/execManageAlerts.ts
@@ -1,12 +1,17 @@
 import assert from 'assert';
 import { spawnSync } from 'child_process';
 
-import { SERVER_PATHS } from '../../consts';
+import { SERVER_PATHS } from './consts';
 
-import { stdoutVar } from '../../shell';
+import { stdoutVar } from './shell';
 
 const MAP_TO_FLAG_BUNDLE = {
-  'alert-overrides': {},
+  'alert-overrides': {
+    '--alert-override-alert-level': 'level',
+    '--alert-override-host-uuid': 'hostUuid',
+    '--alert-override-recipient-uuid': 'recipientUuid',
+    '--alert-override-uuid': 'uuid',
+  },
   'mail-servers': {
     '--mail-server-address': 'address',
     '--mail-server-authentication': 'authentication',
@@ -17,7 +22,13 @@ const MAP_TO_FLAG_BUNDLE = {
     '--mail-server-username': 'username',
     '--mail-server-uuid': 'uuid',
   },
-  recipients: {},
+  recipients: {
+    '--recipient-email': 'email',
+    '--recipient-language': 'language',
+    '--recipient-level': 'level',
+    '--recipient-name': 'name',
+    '--recipient-uuid': 'uuid',
+  },
 };
 
 export const execManageAlerts = (

--- a/striker-ui-api/src/lib/execManageAlerts.ts
+++ b/striker-ui-api/src/lib/execManageAlerts.ts
@@ -58,7 +58,7 @@ export const execManageAlerts = (
     (previous, [key, flag]) => {
       const value = shallow[key];
 
-      if (value) {
+      if (value !== undefined) {
         previous.push(flag, String(value));
       }
 

--- a/striker-ui-api/src/lib/execManageAlerts.ts
+++ b/striker-ui-api/src/lib/execManageAlerts.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
-import { spawnSync } from 'child_process';
+import { SpawnSyncReturns, spawnSync } from 'child_process';
 
-import { SERVER_PATHS } from './consts';
+import { P_UUID, SERVER_PATHS } from './consts';
 
 import { stdoutVar } from './shell';
 
@@ -45,7 +45,7 @@ export const execManageAlerts = (
     body?: Record<string, unknown>;
     uuid?: string;
   } = {},
-) => {
+): { uuid?: string } => {
   const shallow = { ...body };
 
   if (uuid) {
@@ -69,12 +69,16 @@ export const execManageAlerts = (
 
   stdoutVar({ commandArgs }, 'Manage alerts with args: ');
 
+  let result: SpawnSyncReturns<string>;
+
   try {
-    const { error, signal, status, stderr, stdout } = spawnSync(
+    result = spawnSync(
       SERVER_PATHS.usr.sbin['anvil-manage-alerts'].self,
       commandArgs,
       { encoding: 'utf-8', timeout: 10000 },
     );
+
+    const { error, signal, status, stderr, stdout } = result;
 
     stdoutVar(
       { error, signal, status, stderr, stdout },
@@ -95,4 +99,8 @@ export const execManageAlerts = (
   } catch (error) {
     throw new Error(`Failed to complete manage alerts; CAUSE: ${error}`);
   }
+
+  return {
+    uuid: result.stdout.match(new RegExp(P_UUID))?.[0],
+  };
 };

--- a/striker-ui-api/src/lib/execManageAlerts.ts
+++ b/striker-ui-api/src/lib/execManageAlerts.ts
@@ -5,29 +5,33 @@ import { SERVER_PATHS } from './consts';
 
 import { stdoutVar } from './shell';
 
-const MAP_TO_FLAG_BUNDLE = {
+const MAP_TO_FLAG_BUNDLE: {
+  'alert-overrides': Record<keyof AlertOverrideRequestBody | 'uuid', string>;
+  'mail-servers': Record<keyof MailServerRequestBody | 'uuid', string>;
+  recipients: Record<keyof MailRecipientRequestBody | 'uuid', string>;
+} = {
   'alert-overrides': {
-    '--alert-override-alert-level': 'level',
-    '--alert-override-host-uuid': 'hostUuid',
-    '--alert-override-recipient-uuid': 'recipientUuid',
-    '--alert-override-uuid': 'uuid',
+    hostUuid: '--alert-override-host-uuid',
+    level: '--alert-override-alert-level',
+    mailRecipientUuid: '--alert-override-recipient-uuid',
+    uuid: '--alert-override-uuid',
   },
   'mail-servers': {
-    '--mail-server-address': 'address',
-    '--mail-server-authentication': 'authentication',
-    '--mail-server-helo-domain': 'heloDomain',
-    '--mail-server-password': 'password',
-    '--mail-server-port': 'port',
-    '--mail-server-security': 'security',
-    '--mail-server-username': 'username',
-    '--mail-server-uuid': 'uuid',
+    address: '--mail-server-address',
+    authentication: '--mail-server-authentication',
+    heloDomain: '--mail-server-helo-domain',
+    password: '--mail-server-password',
+    port: '--mail-server-port',
+    security: '--mail-server-security',
+    username: '--mail-server-username',
+    uuid: '--mail-server-uuid',
   },
   recipients: {
-    '--recipient-email': 'email',
-    '--recipient-language': 'language',
-    '--recipient-level': 'level',
-    '--recipient-name': 'name',
-    '--recipient-uuid': 'uuid',
+    email: '--recipient-email',
+    language: '--recipient-language',
+    level: '--recipient-level',
+    name: '--recipient-name',
+    uuid: '--recipient-uuid',
   },
 };
 
@@ -51,7 +55,7 @@ export const execManageAlerts = (
   const commandArgs: string[] = Object.entries(
     MAP_TO_FLAG_BUNDLE[entities],
   ).reduce(
-    (previous, [flag, key]) => {
+    (previous, [key, flag]) => {
       const value = shallow[key];
 
       if (value) {

--- a/striker-ui-api/src/lib/request_handlers/alert-override/createAlertOverride.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/createAlertOverride.ts
@@ -1,0 +1,35 @@
+import { RequestHandler } from 'express';
+
+import { execManageAlerts } from '../../execManageAlerts';
+import { getAlertOverrideRequestBody } from './getAlertOverrideRequestBody';
+import { stderr, stdout } from '../../shell';
+
+export const createAlertOverride: RequestHandler<
+  undefined,
+  undefined,
+  AlertOverrideRequestBody
+> = (request, response) => {
+  const { body: rBody = {} } = request;
+
+  stdout(`Begin creating alert override.`);
+
+  let body: AlertOverrideRequestBody;
+
+  try {
+    body = getAlertOverrideRequestBody(rBody);
+  } catch (error) {
+    stderr(`Failed to process alert override input; CAUSE: ${error}`);
+
+    return response.status(400).send();
+  }
+
+  try {
+    execManageAlerts('alert-overrides', 'add', { body });
+  } catch (error) {
+    stderr(`Failed to create alert override; CAUSE: ${error}`);
+
+    return response.status(500).send();
+  }
+
+  return response.status(201).send();
+};

--- a/striker-ui-api/src/lib/request_handlers/alert-override/deleteAlertOverride.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/deleteAlertOverride.ts
@@ -1,0 +1,22 @@
+import { RequestHandler } from 'express';
+
+import { execManageAlerts } from '../../execManageAlerts';
+import { stderr } from '../../shell';
+
+export const deleteAlertOverride: RequestHandler<
+  AlertOverrideParamsDictionary
+> = (request, response) => {
+  const {
+    params: { uuid },
+  } = request;
+
+  try {
+    execManageAlerts('alert-overrides', 'delete', { uuid });
+  } catch (error) {
+    stderr(`Failed to delete alert override: CAUSE: ${error}`);
+
+    return response.status(500).send();
+  }
+
+  return response.status(204).send();
+};

--- a/striker-ui-api/src/lib/request_handlers/alert-override/deleteAlertOverride.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/deleteAlertOverride.ts
@@ -3,9 +3,10 @@ import { RequestHandler } from 'express';
 import { execManageAlerts } from '../../execManageAlerts';
 import { stderr } from '../../shell';
 
-export const deleteAlertOverride: RequestHandler<
-  AlertOverrideParamsDictionary
-> = (request, response) => {
+export const deleteAlertOverride: RequestHandler<AlertOverrideReqParams> = (
+  request,
+  response,
+) => {
   const {
     params: { uuid },
   } = request;

--- a/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverride.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverride.ts
@@ -2,13 +2,28 @@ import { RequestHandler } from 'express';
 
 import { DELETED } from '../../consts';
 
+import { buildUnknownIDCondition } from '../../buildCondition';
 import buildGetRequestHandler from '../buildGetRequestHandler';
 import { buildQueryResultReducer } from '../../buildQueryResultModifier';
 import { getShortHostName } from '../../disassembleHostName';
 
-export const getAlertOverride: RequestHandler = buildGetRequestHandler(
-  (request, options) => {
-    const query = `
+export const getAlertOverride: RequestHandler<
+  AlertOverrideReqParams,
+  undefined,
+  undefined,
+  AlertOverrideReqQuery
+> = buildGetRequestHandler((request, options) => {
+  const {
+    query: { 'mail-recipient': mailRecipient },
+  } = request;
+
+  const { after: mailRecipientCond } = buildUnknownIDCondition(
+    mailRecipient,
+    'b.recipient_uuid',
+    { onFallback: () => 'TRUE' },
+  );
+
+  const query = `
       SELECT
         a.alert_override_uuid,
         a.alert_override_alert_level,
@@ -24,46 +39,46 @@ export const getAlertOverride: RequestHandler = buildGetRequestHandler(
         ON a.alert_override_host_uuid = c.host_uuid
       WHERE a.alert_override_alert_level != -1
         AND b.recipient_name != '${DELETED}'
+        AND ${mailRecipientCond}
       ORDER BY b.recipient_name ASC;`;
 
-    const afterQueryReturn: QueryResultModifierFunction =
-      buildQueryResultReducer<AlertOverrideOverviewList>(
-        (
-          previous,
-          [
-            uuid,
-            level,
-            mailRecipientUuid,
-            mailRecipientName,
-            hostUuid,
+  const afterQueryReturn: QueryResultModifierFunction =
+    buildQueryResultReducer<AlertOverrideOverviewList>(
+      (
+        previous,
+        [
+          uuid,
+          level,
+          mailRecipientUuid,
+          mailRecipientName,
+          hostUuid,
+          hostName,
+          hostType,
+        ],
+      ) => {
+        previous[uuid] = {
+          host: {
             hostName,
             hostType,
-          ],
-        ) => {
-          previous[uuid] = {
-            host: {
-              hostName,
-              hostType,
-              hostUUID: hostUuid,
-              shortHostName: getShortHostName(hostName),
-            },
-            level: Number(level),
-            mailRecipient: {
-              name: mailRecipientName,
-              uuid: mailRecipientUuid,
-            },
-            uuid,
-          };
+            hostUUID: hostUuid,
+            shortHostName: getShortHostName(hostName),
+          },
+          level: Number(level),
+          mailRecipient: {
+            name: mailRecipientName,
+            uuid: mailRecipientUuid,
+          },
+          uuid,
+        };
 
-          return previous;
-        },
-        {},
-      );
+        return previous;
+      },
+      {},
+    );
 
-    if (options) {
-      options.afterQueryReturn = afterQueryReturn;
-    }
+  if (options) {
+    options.afterQueryReturn = afterQueryReturn;
+  }
 
-    return query;
-  },
-);
+  return query;
+});

--- a/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverride.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverride.ts
@@ -31,12 +31,15 @@ export const getAlertOverride: RequestHandler<
         b.recipient_name,
         c.host_uuid,
         c.host_name,
-        c.host_type
+        d.anvil_uuid,
+        d.anvil_name
       FROM alert_overrides AS a
       JOIN recipients AS b
         ON a.alert_override_recipient_uuid = b.recipient_uuid
       JOIN hosts AS c
         ON a.alert_override_host_uuid = c.host_uuid
+      JOIN anvils AS d
+        ON c.host_uuid IN (d.anvil_node1_host_uuid, d.anvil_node2_host_uuid)
       WHERE a.alert_override_alert_level != -1
         AND b.recipient_name != '${DELETED}'
         AND ${mailRecipientCond}
@@ -53,20 +56,24 @@ export const getAlertOverride: RequestHandler<
           mailRecipientName,
           hostUuid,
           hostName,
-          hostType,
+          anvilUuid,
+          anvilName,
         ],
       ) => {
         previous[uuid] = {
-          host: {
-            hostName,
-            hostType,
-            hostUUID: hostUuid,
-            shortHostName: getShortHostName(hostName),
-          },
           level: Number(level),
           mailRecipient: {
             name: mailRecipientName,
             uuid: mailRecipientUuid,
+          },
+          node: {
+            name: anvilName,
+            uuid: anvilUuid,
+          },
+          subnode: {
+            name: hostName,
+            short: getShortHostName(hostName),
+            uuid: hostUuid,
           },
           uuid,
         };

--- a/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverride.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverride.ts
@@ -1,0 +1,69 @@
+import { RequestHandler } from 'express';
+
+import { DELETED } from '../../consts';
+
+import buildGetRequestHandler from '../buildGetRequestHandler';
+import { buildQueryResultReducer } from '../../buildQueryResultModifier';
+import { getShortHostName } from '../../disassembleHostName';
+
+export const getAlertOverride: RequestHandler = buildGetRequestHandler(
+  (request, options) => {
+    const query = `
+      SELECT
+        a.alert_override_uuid,
+        a.alert_override_alert_level,
+        b.recipient_uuid,
+        b.recipient_name,
+        c.host_uuid,
+        c.host_name,
+        c.host_type
+      FROM alert_overrides AS a
+      JOIN recipients AS b
+        ON a.alert_override_recipient_uuid = b.recipient_uuid
+      JOIN hosts AS c
+        ON a.alert_override_host_uuid = c.host_uuid
+      WHERE a.alert_override_alert_level != -1
+        AND b.recipient_name != '${DELETED}'
+      ORDER BY b.recipient_name ASC;`;
+
+    const afterQueryReturn: QueryResultModifierFunction =
+      buildQueryResultReducer<AlertOverrideOverviewList>(
+        (
+          previous,
+          [
+            uuid,
+            level,
+            mailRecipientUuid,
+            mailRecipientName,
+            hostUuid,
+            hostName,
+            hostType,
+          ],
+        ) => {
+          previous[uuid] = {
+            host: {
+              hostName,
+              hostType,
+              hostUUID: hostUuid,
+              shortHostName: getShortHostName(hostName),
+            },
+            level: Number(level),
+            mailRecipient: {
+              name: mailRecipientName,
+              uuid: mailRecipientUuid,
+            },
+            uuid,
+          };
+
+          return previous;
+        },
+        {},
+      );
+
+    if (options) {
+      options.afterQueryReturn = afterQueryReturn;
+    }
+
+    return query;
+  },
+);

--- a/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverrideDetail.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverrideDetail.ts
@@ -7,7 +7,7 @@ import { buildQueryResultModifier } from '../../buildQueryResultModifier';
 import { getShortHostName } from '../../disassembleHostName';
 import { sanitize } from '../../sanitize';
 
-export const getAlertOverrideDetail: RequestHandler<AlertOverrideParamsDictionary> =
+export const getAlertOverrideDetail: RequestHandler<AlertOverrideReqParams> =
   buildGetRequestHandler((request, options) => {
     const {
       params: { uuid: rUuid },

--- a/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverrideDetail.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverrideDetail.ts
@@ -23,12 +23,15 @@ export const getAlertOverrideDetail: RequestHandler<AlertOverrideReqParams> =
         b.recipient_name,
         c.host_uuid,
         c.host_name,
-        c.host_type
+        d.anvil_uuid,
+        d.anvil_name
       FROM alert_overrides AS a
       JOIN recipients AS b
         ON a.alert_override_recipient_uuid = b.recipient_uuid
       JOIN hosts AS c
         ON a.alert_override_host_uuid = c.host_uuid
+      JOIN anvils AS d
+        ON c.host_uuid IN (d.anvil_node1_host_uuid, d.anvil_node2_host_uuid)
       WHERE a.alert_override_alert_level != -1
         AND b.recipient_name != '${DELETED}'
         AND a.alert_override_uuid = '${uuid}'
@@ -48,21 +51,25 @@ export const getAlertOverrideDetail: RequestHandler<AlertOverrideReqParams> =
             mailRecipientName,
             hostUuid,
             hostName,
-            hostType,
+            anvilUuid,
+            anvilName,
           ],
         } = rows;
 
         return {
-          host: {
-            hostName,
-            hostType,
-            hostUUID: hostUuid,
-            shortHostName: getShortHostName(hostName),
-          },
           level: Number(level),
           mailRecipient: {
             name: mailRecipientName,
             uuid: mailRecipientUuid,
+          },
+          node: {
+            name: anvilName,
+            uuid: anvilUuid,
+          },
+          subnode: {
+            name: hostName,
+            short: getShortHostName(hostName),
+            uuid: hostUuid,
           },
           uuid,
         };

--- a/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverrideDetail.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverrideDetail.ts
@@ -1,0 +1,76 @@
+import { RequestHandler } from 'express';
+
+import { DELETED } from '../../consts';
+
+import buildGetRequestHandler from '../buildGetRequestHandler';
+import { buildQueryResultModifier } from '../../buildQueryResultModifier';
+import { getShortHostName } from '../../disassembleHostName';
+import { sanitize } from '../../sanitize';
+
+export const getAlertOverrideDetail: RequestHandler<AlertOverrideParamsDictionary> =
+  buildGetRequestHandler((request, options) => {
+    const {
+      params: { uuid: rUuid },
+    } = request;
+
+    const uuid = sanitize(rUuid, 'string', { modifierType: 'sql' });
+
+    const query = `
+      SELECT
+        a.alert_override_uuid,
+        a.alert_override_alert_level,
+        b.recipient_uuid,
+        b.recipient_name,
+        c.host_uuid,
+        c.host_name,
+        c.host_type
+      FROM alert_overrides AS a
+      JOIN recipients AS b
+        ON a.alert_override_recipient_uuid = b.recipient_uuid
+      JOIN hosts AS c
+        ON a.alert_override_host_uuid = c.host_uuid
+      WHERE a.alert_override_alert_level != -1
+        AND b.recipient_name != '${DELETED}'
+        AND a.alert_override_uuid = '${uuid}'
+      ORDER BY b.recipient_name ASC;`;
+
+    const afterQueryReturn: QueryResultModifierFunction =
+      buildQueryResultModifier<AlertOverrideDetail | undefined>((rows) => {
+        if (!rows.length) {
+          return undefined;
+        }
+
+        const {
+          0: [
+            uuid,
+            level,
+            mailRecipientUuid,
+            mailRecipientName,
+            hostUuid,
+            hostName,
+            hostType,
+          ],
+        } = rows;
+
+        return {
+          host: {
+            hostName,
+            hostType,
+            hostUUID: hostUuid,
+            shortHostName: getShortHostName(hostName),
+          },
+          level: Number(level),
+          mailRecipient: {
+            name: mailRecipientName,
+            uuid: mailRecipientUuid,
+          },
+          uuid,
+        };
+      });
+
+    if (options) {
+      options.afterQueryReturn = afterQueryReturn;
+    }
+
+    return query;
+  });

--- a/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverrideRequestBody.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/getAlertOverrideRequestBody.ts
@@ -1,0 +1,45 @@
+import assert from 'assert';
+
+import { REP_UUID } from '../../consts';
+
+import { sanitize } from '../../sanitize';
+
+export const getAlertOverrideRequestBody = (
+  body: Partial<AlertOverrideRequestBody>,
+  uuid?: string,
+): AlertOverrideRequestBody => {
+  const {
+    hostUuid: rHostUuid,
+    level: rLevel,
+    mailRecipientUuid: rMailRecipientUuid,
+  } = body;
+
+  const hostUuid = sanitize(rHostUuid, 'string');
+  const level = sanitize(rLevel, 'number');
+  const mailRecipientUuid = sanitize(rMailRecipientUuid, 'string');
+
+  if (uuid) {
+    assert(REP_UUID.test(uuid), `Expected valid UUIDv4; got [${uuid}]`);
+  }
+
+  assert(
+    REP_UUID.test(hostUuid),
+    `Expected valid host UUIDv4; got [${hostUuid}]`,
+  );
+
+  assert(
+    Number.isSafeInteger(level),
+    `Expected level to be an integer; got [${level}]`,
+  );
+
+  assert(
+    REP_UUID.test(mailRecipientUuid),
+    `Expected valid mail recipient UUIDv4; got [${mailRecipientUuid}]`,
+  );
+
+  return {
+    hostUuid,
+    level,
+    mailRecipientUuid,
+  };
+};

--- a/striker-ui-api/src/lib/request_handlers/alert-override/index.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/index.ts
@@ -1,0 +1,5 @@
+export * from './createAlertOverride';
+export * from './deleteAlertOverride';
+export * from './getAlertOverride';
+export * from './getAlertOverrideDetail';
+export * from './updateAlertOverride';

--- a/striker-ui-api/src/lib/request_handlers/alert-override/updateAlertOverride.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/updateAlertOverride.ts
@@ -1,0 +1,38 @@
+import { RequestHandler } from 'express';
+
+import { execManageAlerts } from '../../execManageAlerts';
+import { getAlertOverrideRequestBody } from './getAlertOverrideRequestBody';
+import { stderr, stdout } from '../../shell';
+
+export const updateAlertOverride: RequestHandler<
+  AlertOverrideParamsDictionary,
+  undefined,
+  AlertOverrideRequestBody
+> = (request, response) => {
+  const {
+    body: rBody = {},
+    params: { uuid },
+  } = request;
+
+  stdout('Begin updating alert override.');
+
+  let body: AlertOverrideRequestBody;
+
+  try {
+    body = getAlertOverrideRequestBody(rBody, uuid);
+  } catch (error) {
+    stderr(`Failed to process alert override input; CAUSE: ${error}`);
+
+    return response.status(400).send();
+  }
+
+  try {
+    execManageAlerts('alert-overrides', 'edit', { body, uuid });
+  } catch (error) {
+    stderr(`Failed to update alert override; CAUSE: ${error}`);
+
+    return response.status(500).send();
+  }
+
+  return response.status(200).send();
+};

--- a/striker-ui-api/src/lib/request_handlers/alert-override/updateAlertOverride.ts
+++ b/striker-ui-api/src/lib/request_handlers/alert-override/updateAlertOverride.ts
@@ -5,7 +5,7 @@ import { getAlertOverrideRequestBody } from './getAlertOverrideRequestBody';
 import { stderr, stdout } from '../../shell';
 
 export const updateAlertOverride: RequestHandler<
-  AlertOverrideParamsDictionary,
+  AlertOverrideReqParams,
   undefined,
   AlertOverrideRequestBody
 > = (request, response) => {

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/createMailRecipient.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/createMailRecipient.ts
@@ -11,14 +11,14 @@ export const createMailRecipient: RequestHandler<
 > = (request, response) => {
   const { body: rBody = {} } = request;
 
-  stdout('Begin creating alert recipient.');
+  stdout('Begin creating mail recipient.');
 
   let reqBody: MailRecipientRequestBody;
 
   try {
     reqBody = getMailRecipientRequestBody(rBody);
   } catch (error) {
-    stderr(`Failed to process alert recipient input; CAUSE: ${error}`);
+    stderr(`Failed to process mail recipient input; CAUSE: ${error}`);
 
     return response.status(400).send();
   }
@@ -32,7 +32,7 @@ export const createMailRecipient: RequestHandler<
 
     resBody = { uuid };
   } catch (error) {
-    stderr(`Failed to create alert recipient; CAUSE: ${error}`);
+    stderr(`Failed to create mail recipient; CAUSE: ${error}`);
 
     return response.status(500).send();
   }

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/createMailRecipient.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/createMailRecipient.ts
@@ -6,30 +6,36 @@ import { stderr, stdout } from '../../shell';
 
 export const createMailRecipient: RequestHandler<
   undefined,
-  undefined,
+  MailRecipientResponseBody | undefined,
   MailRecipientRequestBody
 > = (request, response) => {
   const { body: rBody = {} } = request;
 
   stdout('Begin creating alert recipient.');
 
-  let body: MailRecipientRequestBody;
+  let reqBody: MailRecipientRequestBody;
 
   try {
-    body = getMailRecipientRequestBody(rBody);
+    reqBody = getMailRecipientRequestBody(rBody);
   } catch (error) {
     stderr(`Failed to process alert recipient input; CAUSE: ${error}`);
 
     return response.status(400).send();
   }
 
+  let resBody: MailRecipientResponseBody | undefined;
+
   try {
-    execManageAlerts('recipients', 'add', { body });
+    const { uuid = '' } = execManageAlerts('recipients', 'add', {
+      body: reqBody,
+    });
+
+    resBody = { uuid };
   } catch (error) {
     stderr(`Failed to create alert recipient; CAUSE: ${error}`);
 
     return response.status(500).send();
   }
 
-  return response.status(201).send();
+  return response.status(201).send(resBody);
 };

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/createMailRecipient.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/createMailRecipient.ts
@@ -1,0 +1,35 @@
+import { RequestHandler } from 'express';
+
+import { execManageAlerts } from '../../execManageAlerts';
+import { getMailRecipientRequestBody } from './getMailRecipientRequestBody';
+import { stderr, stdout } from '../../shell';
+
+export const createMailRecipient: RequestHandler<
+  undefined,
+  undefined,
+  MailRecipientRequestBody
+> = (request, response) => {
+  const { body: rBody = {} } = request;
+
+  stdout('Begin creating alert recipient.');
+
+  let body: MailRecipientRequestBody;
+
+  try {
+    body = getMailRecipientRequestBody(rBody);
+  } catch (error) {
+    stderr(`Failed to process alert recipient input; CAUSE: ${error}`);
+
+    return response.status(400).send();
+  }
+
+  try {
+    execManageAlerts('recipients', 'add', { body });
+  } catch (error) {
+    stderr(`Failed to create alert recipient; CAUSE: ${error}`);
+
+    return response.status(500).send();
+  }
+
+  return response.status(201).send();
+};

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/deleteMailRecipient.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/deleteMailRecipient.ts
@@ -1,0 +1,22 @@
+import { RequestHandler } from 'express';
+
+import { execManageAlerts } from '../../execManageAlerts';
+import { stderr } from '../../shell';
+
+export const deleteMailRecipient: RequestHandler<
+  MailRecipientParamsDictionary
+> = (request, response) => {
+  const {
+    params: { uuid },
+  } = request;
+
+  try {
+    execManageAlerts('recipients', 'delete', { uuid });
+  } catch (error) {
+    stderr(`Failed to delete alert recipient; CAUSE: ${error}`);
+
+    return response.status(500).send();
+  }
+
+  return response.status(204).send();
+};

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/deleteMailRecipient.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/deleteMailRecipient.ts
@@ -1,14 +1,35 @@
 import { RequestHandler } from 'express';
 
+import { query } from '../../accessModule';
 import { execManageAlerts } from '../../execManageAlerts';
+import { sanitize } from '../../sanitize';
 import { stderr } from '../../shell';
 
 export const deleteMailRecipient: RequestHandler<
   MailRecipientParamsDictionary
-> = (request, response) => {
+> = async (request, response) => {
   const {
-    params: { uuid },
+    params: { uuid: rUuid },
   } = request;
+
+  const uuid = sanitize(rUuid, 'string', { modifierType: 'sql' });
+
+  try {
+    const rows = await query<[string][]>(
+      `SELECT alert_override_uuid
+        FROM alert_overrides
+        WHERE alert_override_alert_level != -1
+          AND alert_override_recipient_uuid = '${uuid}';`,
+    );
+
+    rows.forEach(([u]) =>
+      execManageAlerts('alert-overrides', 'delete', { uuid: u }),
+    );
+  } catch (error) {
+    stderr(`Failed to delete related alert override records; CAUSE ${error}`);
+
+    return response.status(500).send();
+  }
 
   try {
     execManageAlerts('recipients', 'delete', { uuid });

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/getMailRecipient.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/getMailRecipient.ts
@@ -1,0 +1,34 @@
+import { RequestHandler } from 'express';
+
+import { DELETED } from '../../consts';
+
+import buildGetRequestHandler from '../buildGetRequestHandler';
+import { buildQueryResultReducer } from '../../buildQueryResultModifier';
+
+export const getMailRecipient: RequestHandler = buildGetRequestHandler(
+  (request, options) => {
+    const query = `
+      SELECT
+        a.recipient_uuid,
+        a.recipient_name
+      FROM recipients AS a
+      WHERE a.recipient_name != '${DELETED}'
+      ORDER BY a.recipient_name ASC;`;
+
+    const afterQueryReturn: QueryResultModifierFunction =
+      buildQueryResultReducer<MailRecipientOverviewList>(
+        (previous, [uuid, name]) => {
+          previous[uuid] = { name, uuid };
+
+          return previous;
+        },
+        {},
+      );
+
+    if (options) {
+      options.afterQueryReturn = afterQueryReturn;
+    }
+
+    return query;
+  },
+);

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/getMailRecipientDetail.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/getMailRecipientDetail.ts
@@ -1,0 +1,53 @@
+import { RequestHandler } from 'express';
+
+import { DELETED } from '../../consts';
+
+import buildGetRequestHandler from '../buildGetRequestHandler';
+import { buildQueryResultModifier } from '../../buildQueryResultModifier';
+import { sanitize } from '../../sanitize';
+
+export const getMailRecipientDetail: RequestHandler<MailRecipientParamsDictionary> =
+  buildGetRequestHandler((request, options) => {
+    const {
+      params: { uuid: rUuid },
+    } = request;
+
+    const uuid = sanitize(rUuid, 'string', { modifierType: 'sql' });
+
+    const query = `
+      SELECT
+        a.recipient_uuid,
+        a.recipient_name,
+        a.recipient_email,
+        a.recipient_language,
+        a.recipient_level
+      FROM recipients AS a
+      WHERE a.recipient_name != '${DELETED}'
+        AND a.recipient_uuid = '${uuid}'
+      ORDER BY a.recipient_name ASC;`;
+
+    const afterQueryReturn: QueryResultModifierFunction =
+      buildQueryResultModifier<MailRecipientDetail | undefined>((rows) => {
+        if (!rows.length) {
+          return undefined;
+        }
+
+        const {
+          0: [uuid, name, email, language, level],
+        } = rows;
+
+        return {
+          email,
+          language,
+          level: Number(level),
+          name,
+          uuid,
+        };
+      });
+
+    if (options) {
+      options.afterQueryReturn = afterQueryReturn;
+    }
+
+    return query;
+  });

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/getMailRecipientRequestBody.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/getMailRecipientRequestBody.ts
@@ -1,0 +1,49 @@
+import assert from 'assert';
+
+import { REP_UUID } from '../../consts';
+
+import { sanitize } from '../../sanitize';
+
+export const getMailRecipientRequestBody = (
+  body: Partial<MailRecipientRequestBody>,
+  uuid?: string,
+): MailRecipientRequestBody => {
+  const {
+    email: rEmail,
+    language: rLanguage,
+    level: rLevel,
+    name: rName,
+  } = body;
+
+  const email = sanitize(rEmail, 'string');
+  const language = sanitize(rLanguage, 'string', { fallback: 'en_CA' });
+  const level = sanitize(rLevel, 'number');
+  const name = sanitize(rName, 'string');
+
+  if (uuid) {
+    assert(REP_UUID.test(uuid), `Expected valid UUIDv4; got [${uuid}]`);
+  }
+
+  assert.ok(email.length, `Expected email; got [${email}]`);
+
+  if (language) {
+    assert.ok(
+      language.length,
+      `Expected valid language code; got [${language}]`,
+    );
+  }
+
+  assert(
+    Number.isSafeInteger(level),
+    `Expected level to be an integer; got [${level}]`,
+  );
+
+  assert.ok(name.length, `Expected name; got [${name}]`);
+
+  return {
+    email,
+    language,
+    level,
+    name,
+  };
+};

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/index.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/index.ts
@@ -1,0 +1,5 @@
+export * from './createMailRecipient';
+export * from './deleteMailRecipient';
+export * from './getMailRecipient';
+export * from './getMailRecipientDetail';
+export * from './updateMailRecipient';

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/updateMailRecipient.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/updateMailRecipient.ts
@@ -14,14 +14,14 @@ export const updateMailRecipient: RequestHandler<
     params: { uuid },
   } = request;
 
-  stdout('Begin updating alert recipient.');
+  stdout('Begin updating mail recipient.');
 
   let body: MailRecipientRequestBody;
 
   try {
     body = getMailRecipientRequestBody(rBody, uuid);
   } catch (error) {
-    stderr(`Failed to process alert recipient input; CAUSE: ${error}`);
+    stderr(`Failed to process mail recipient input; CAUSE: ${error}`);
 
     return response.status(400).send();
   }
@@ -29,7 +29,7 @@ export const updateMailRecipient: RequestHandler<
   try {
     execManageAlerts('recipients', 'edit', { body, uuid });
   } catch (error) {
-    stderr(`Failed to update mail server; CAUSE: ${error}`);
+    stderr(`Failed to update mail recipient; CAUSE: ${error}`);
 
     return response.status(500).send();
   }

--- a/striker-ui-api/src/lib/request_handlers/mail-recipient/updateMailRecipient.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-recipient/updateMailRecipient.ts
@@ -1,0 +1,38 @@
+import { RequestHandler } from 'express';
+
+import { execManageAlerts } from '../../execManageAlerts';
+import { getMailRecipientRequestBody } from './getMailRecipientRequestBody';
+import { stderr, stdout } from '../../shell';
+
+export const updateMailRecipient: RequestHandler<
+  MailRecipientParamsDictionary,
+  undefined,
+  MailRecipientRequestBody
+> = (request, response) => {
+  const {
+    body: rBody = {},
+    params: { uuid },
+  } = request;
+
+  stdout('Begin updating alert recipient.');
+
+  let body: MailRecipientRequestBody;
+
+  try {
+    body = getMailRecipientRequestBody(rBody, uuid);
+  } catch (error) {
+    stderr(`Failed to process alert recipient input; CAUSE: ${error}`);
+
+    return response.status(400).send();
+  }
+
+  try {
+    execManageAlerts('recipients', 'edit', { body, uuid });
+  } catch (error) {
+    stderr(`Failed to update mail server; CAUSE: ${error}`);
+
+    return response.status(500).send();
+  }
+
+  return response.status(200).send();
+};

--- a/striker-ui-api/src/lib/request_handlers/mail-server/createMailServer.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/createMailServer.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express';
 
-import { execManageAlerts } from './execManageAlerts';
+import { execManageAlerts } from '../../execManageAlerts';
 import { getMailServerRequestBody } from './getMailServerRequestBody';
 import { stderr, stdout } from '../../shell';
 

--- a/striker-ui-api/src/lib/request_handlers/mail-server/createMailServer.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/createMailServer.ts
@@ -1,0 +1,35 @@
+import { RequestHandler } from 'express';
+
+import { execManageAlerts } from './execManageAlerts';
+import { getMailServerRequestBody } from './getMailServerRequestBody';
+import { stderr, stdout } from '../../shell';
+
+export const createMailServer: RequestHandler<
+  undefined,
+  undefined,
+  MailServerRequestBody
+> = (request, response) => {
+  const { body: rBody = {} } = request;
+
+  stdout('Begin creating mail server.');
+
+  let body: MailServerRequestBody;
+
+  try {
+    body = getMailServerRequestBody(rBody);
+  } catch (error) {
+    stderr(`Failed to process mail server input; CAUSE: ${error}`);
+
+    return response.status(400).send();
+  }
+
+  try {
+    execManageAlerts('mail-servers', 'add', { body });
+  } catch (error) {
+    stderr(`Failed to create mail server; CAUSE: ${error}`);
+
+    return response.status(500).send();
+  }
+
+  return response.status(201).send();
+};

--- a/striker-ui-api/src/lib/request_handlers/mail-server/deleteMailServer.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/deleteMailServer.ts
@@ -1,0 +1,23 @@
+import { RequestHandler } from 'express';
+
+import { execManageAlerts } from './execManageAlerts';
+import { stderr } from '../../shell';
+
+export const deleteMailServer: RequestHandler<MailServerParamsDictionary> = (
+  request,
+  response,
+) => {
+  const {
+    params: { uuid },
+  } = request;
+
+  try {
+    execManageAlerts('mail-servers', 'delete', { uuid });
+  } catch (error) {
+    stderr(`Failed to delete mail server; CAUSE: ${error}`);
+
+    return response.status(500).send();
+  }
+
+  return response.status(204).send();
+};

--- a/striker-ui-api/src/lib/request_handlers/mail-server/deleteMailServer.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/deleteMailServer.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express';
 
-import { execManageAlerts } from './execManageAlerts';
+import { execManageAlerts } from '../../execManageAlerts';
 import { stderr } from '../../shell';
 
 export const deleteMailServer: RequestHandler<MailServerParamsDictionary> = (

--- a/striker-ui-api/src/lib/request_handlers/mail-server/execManageAlerts.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/execManageAlerts.ts
@@ -1,0 +1,83 @@
+import assert from 'assert';
+import { spawnSync } from 'child_process';
+
+import { SERVER_PATHS } from '../../consts';
+
+import { stdoutVar } from '../../shell';
+
+const MAP_TO_FLAG_BUNDLE = {
+  'alert-overrides': {},
+  'mail-servers': {
+    '--mail-server-address': 'address',
+    '--mail-server-authentication': 'authentication',
+    '--mail-server-helo-domain': 'heloDomain',
+    '--mail-server-password': 'password',
+    '--mail-server-port': 'port',
+    '--mail-server-security': 'security',
+    '--mail-server-username': 'username',
+    '--mail-server-uuid': 'uuid',
+  },
+  recipients: {},
+};
+
+export const execManageAlerts = (
+  entities: 'alert-overrides' | 'mail-servers' | 'recipients',
+  operation: 'add' | 'edit' | 'delete',
+  {
+    body,
+    uuid,
+  }: {
+    body?: Record<string, unknown>;
+    uuid?: string;
+  } = {},
+) => {
+  const shallow = { ...body };
+
+  if (uuid) {
+    shallow.uuid = uuid;
+  }
+
+  const commandArgs: string[] = Object.entries(
+    MAP_TO_FLAG_BUNDLE[entities],
+  ).reduce(
+    (previous, [flag, key]) => {
+      const value = shallow[key];
+
+      if (value) {
+        previous.push(flag, String(value));
+      }
+
+      return previous;
+    },
+    [`--${entities}`, `--${operation}`, '--yes'],
+  );
+
+  stdoutVar({ commandArgs }, 'Manage alerts with args: ');
+
+  try {
+    const { error, signal, status, stderr, stdout } = spawnSync(
+      SERVER_PATHS.usr.sbin['anvil-manage-alerts'].self,
+      commandArgs,
+      { encoding: 'utf-8', timeout: 10000 },
+    );
+
+    stdoutVar(
+      { error, signal, status, stderr, stdout },
+      'Manage alerts returned: ',
+    );
+
+    assert.strictEqual(
+      status,
+      0,
+      `Expected status to be 0, but got [${status}]`,
+    );
+
+    assert.strictEqual(
+      error,
+      undefined,
+      `Expected no error, but got [${error}]`,
+    );
+  } catch (error) {
+    throw new Error(`Failed to complete manage alerts; CAUSE: ${error}`);
+  }
+};

--- a/striker-ui-api/src/lib/request_handlers/mail-server/getMailServer.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/getMailServer.ts
@@ -1,0 +1,39 @@
+import { RequestHandler } from 'express';
+
+import { DELETED } from '../../consts';
+
+import buildGetRequestHandler from '../buildGetRequestHandler';
+import { buildQueryResultReducer } from '../../buildQueryResultModifier';
+
+export const getMailServer: RequestHandler = buildGetRequestHandler(
+  (request, options) => {
+    const query = `
+      SELECT
+        a.mail_server_uuid,
+        a.mail_server_address,
+        a.mail_server_port
+      FROM mail_servers AS a
+      WHERE a.mail_server_helo_domain != '${DELETED}'
+      ORDER BY a.mail_server_address;`;
+
+    const afterQueryReturn: QueryResultModifierFunction =
+      buildQueryResultReducer<MailServerOverviewList>(
+        (previous, [uuid, address, port]) => {
+          previous[uuid] = {
+            address,
+            port: Number(port),
+            uuid,
+          };
+
+          return previous;
+        },
+        {},
+      );
+
+    if (options) {
+      options.afterQueryReturn = afterQueryReturn;
+    }
+
+    return query;
+  },
+);

--- a/striker-ui-api/src/lib/request_handlers/mail-server/getMailServerDetail.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/getMailServerDetail.ts
@@ -1,0 +1,68 @@
+import { RequestHandler } from 'express';
+
+import { DELETED } from '../../consts';
+
+import buildGetRequestHandler from '../buildGetRequestHandler';
+import { buildQueryResultModifier } from '../../buildQueryResultModifier';
+import { sanitize } from '../../sanitize';
+
+export const getMailServerDetail: RequestHandler<MailServerParamsDictionary> =
+  buildGetRequestHandler((request, options) => {
+    const {
+      params: { uuid: rUuid },
+    } = request;
+
+    const uuid = sanitize(rUuid, 'string', { modifierType: 'sql' });
+
+    const query = `
+      SELECT
+        a.mail_server_uuid,
+        a.mail_server_address,
+        a.mail_server_port,
+        a.mail_server_username,
+        a.mail_server_password,
+        a.mail_server_security,
+        a.mail_server_authentication,
+        a.mail_server_helo_domain
+      FROM mail_servers AS a
+      WHERE a.mail_server_helo_domain != '${DELETED}'
+        AND a.mail_server_uuid = '${uuid}'
+      ORDER BY a.mail_server_address ASC;`;
+
+    const afterQueryReturn: QueryResultModifierFunction =
+      buildQueryResultModifier<MailServerDetail | undefined>((rows) => {
+        if (!rows.length) {
+          return undefined;
+        }
+
+        const {
+          0: [
+            uuid,
+            address,
+            port,
+            username,
+            password,
+            security,
+            authentication,
+            heloDomain,
+          ],
+        } = rows;
+
+        return {
+          address,
+          authentication,
+          heloDomain,
+          password,
+          port: Number(port),
+          security,
+          username,
+          uuid,
+        };
+      });
+
+    if (options) {
+      options.afterQueryReturn = afterQueryReturn;
+    }
+
+    return query;
+  });

--- a/striker-ui-api/src/lib/request_handlers/mail-server/getMailServerRequestBody.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/getMailServerRequestBody.ts
@@ -1,0 +1,56 @@
+import assert from 'assert';
+
+import { sanitize } from '../../sanitize';
+
+export const getMailServerRequestBody = (
+  body: Partial<MailServerRequestBody>,
+): MailServerRequestBody => {
+  const {
+    address: rAddress,
+    authentication: rAuthentication,
+    heloDomain: rHeloDomain,
+    password: rPassword,
+    port: rPort,
+    security: rSecurity,
+    username: rUsername,
+  } = body;
+
+  const address = sanitize(rAddress, 'string');
+  const authentication = sanitize(rAuthentication, 'string', {
+    fallback: 'none',
+  });
+  const heloDomain = sanitize(rHeloDomain, 'string');
+  const password = sanitize(rPassword, 'string');
+  const port = sanitize(rPort, 'number', { fallback: 587 });
+  const security = sanitize(rSecurity, 'string', { fallback: 'none' });
+  const username = sanitize(rUsername, 'string');
+
+  assert.ok(address.length, `Expected address; got [${address}]`);
+
+  assert(
+    ['none', 'plain-text', 'encrypted'].includes(authentication),
+    `Expected authentication to be 'none', 'plain-text', or 'encrypted'; got [${authentication}]`,
+  );
+
+  assert.ok(heloDomain.length, `Expected HELO domain; got [${heloDomain}]`);
+
+  assert(
+    Number.isSafeInteger(port),
+    `Expected port to be an integer; got [${port}]`,
+  );
+
+  assert(
+    ['none', 'starttls', 'tls-ssl'].includes(security),
+    `Expected security to be 'none', 'starttls', or 'tls-ssl'; got [${security}]`,
+  );
+
+  return {
+    address,
+    authentication,
+    heloDomain,
+    password,
+    port,
+    security,
+    username,
+  };
+};

--- a/striker-ui-api/src/lib/request_handlers/mail-server/getMailServerRequestBody.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/getMailServerRequestBody.ts
@@ -1,9 +1,12 @@
 import assert from 'assert';
 
+import { REP_UUID } from '../../consts';
+
 import { sanitize } from '../../sanitize';
 
 export const getMailServerRequestBody = (
   body: Partial<MailServerRequestBody>,
+  uuid?: string,
 ): MailServerRequestBody => {
   const {
     address: rAddress,
@@ -24,6 +27,10 @@ export const getMailServerRequestBody = (
   const port = sanitize(rPort, 'number', { fallback: 587 });
   const security = sanitize(rSecurity, 'string', { fallback: 'none' });
   const username = sanitize(rUsername, 'string');
+
+  if (uuid) {
+    assert(REP_UUID.test(uuid), `Expected valid UUIDv4; got [${uuid}]`);
+  }
 
   assert.ok(address.length, `Expected address; got [${address}]`);
 

--- a/striker-ui-api/src/lib/request_handlers/mail-server/index.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/index.ts
@@ -1,0 +1,5 @@
+export * from './createMailServer';
+export * from './deleteMailServer';
+export * from './getMailServer';
+export * from './getMailServerDetail';
+export * from './updateMailServer';

--- a/striker-ui-api/src/lib/request_handlers/mail-server/updateMailServer.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/updateMailServer.ts
@@ -1,0 +1,43 @@
+import assert from 'assert';
+import { RequestHandler } from 'express';
+
+import { REP_UUID } from '../../consts';
+
+import { execManageAlerts } from './execManageAlerts';
+import { getMailServerRequestBody } from './getMailServerRequestBody';
+import { stderr, stdout } from '../../shell';
+
+export const updateMailServer: RequestHandler<
+  MailServerParamsDictionary,
+  undefined,
+  MailServerRequestBody
+> = (request, response) => {
+  const {
+    body: rBody = {},
+    params: { uuid },
+  } = request;
+
+  stdout('Begin updating mail server.');
+
+  let body: MailServerRequestBody;
+
+  try {
+    assert(REP_UUID.test(uuid), `Expected valid UUIDv4; got [${uuid}]`);
+
+    body = getMailServerRequestBody(rBody);
+  } catch (error) {
+    stderr(`Failed to process mail server input; CAUSE: ${error}`);
+
+    return response.status(400).send();
+  }
+
+  try {
+    execManageAlerts('mail-servers', 'edit', { body, uuid });
+  } catch (error) {
+    stderr(`Failed to update mail server; CAUSE: ${error}`);
+
+    return response.status(500).send();
+  }
+
+  return response.status(200).send();
+};

--- a/striker-ui-api/src/lib/request_handlers/mail-server/updateMailServer.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/updateMailServer.ts
@@ -3,7 +3,7 @@ import { RequestHandler } from 'express';
 
 import { REP_UUID } from '../../consts';
 
-import { execManageAlerts } from './execManageAlerts';
+import { execManageAlerts } from '../../execManageAlerts';
 import { getMailServerRequestBody } from './getMailServerRequestBody';
 import { stderr, stdout } from '../../shell';
 

--- a/striker-ui-api/src/lib/request_handlers/mail-server/updateMailServer.ts
+++ b/striker-ui-api/src/lib/request_handlers/mail-server/updateMailServer.ts
@@ -1,7 +1,4 @@
-import assert from 'assert';
 import { RequestHandler } from 'express';
-
-import { REP_UUID } from '../../consts';
 
 import { execManageAlerts } from '../../execManageAlerts';
 import { getMailServerRequestBody } from './getMailServerRequestBody';
@@ -22,9 +19,7 @@ export const updateMailServer: RequestHandler<
   let body: MailServerRequestBody;
 
   try {
-    assert(REP_UUID.test(uuid), `Expected valid UUIDv4; got [${uuid}]`);
-
-    body = getMailServerRequestBody(rBody);
+    body = getMailServerRequestBody(rBody, uuid);
   } catch (error) {
     stderr(`Failed to process mail server input; CAUSE: ${error}`);
 

--- a/striker-ui-api/src/routes/alert-override.ts
+++ b/striker-ui-api/src/routes/alert-override.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+
+import {
+  createAlertOverride,
+  deleteAlertOverride,
+  getAlertOverride,
+  getAlertOverrideDetail,
+  updateAlertOverride,
+} from '../lib/request_handlers/alert-override';
+
+const router = express.Router();
+
+router
+  .delete('/:uuid', deleteAlertOverride)
+  .get('/', getAlertOverride)
+  .get('/:uuid', getAlertOverrideDetail)
+  .post('/', createAlertOverride)
+  .put('/:uuid', updateAlertOverride);
+
+export default router;

--- a/striker-ui-api/src/routes/index.ts
+++ b/striker-ui-api/src/routes/index.ts
@@ -7,6 +7,7 @@ import fileRouter from './file';
 import hostRouter from './host';
 import initRouter from './init';
 import jobRouter from './job';
+import mailServerRouter from './mail-server';
 import manifestRouter from './manifest';
 import networkInterfaceRouter from './network-interface';
 import serverRouter from './server';
@@ -23,6 +24,7 @@ const routes = {
     file: fileRouter,
     host: hostRouter,
     job: jobRouter,
+    'mail-server': mailServerRouter,
     manifest: manifestRouter,
     'network-interface': networkInterfaceRouter,
     server: serverRouter,

--- a/striker-ui-api/src/routes/index.ts
+++ b/striker-ui-api/src/routes/index.ts
@@ -1,3 +1,4 @@
+import alertOverrideRouter from './alert-override';
 import anvilRouter from './anvil';
 import authRouter from './auth';
 import commandRouter from './command';
@@ -7,6 +8,7 @@ import fileRouter from './file';
 import hostRouter from './host';
 import initRouter from './init';
 import jobRouter from './job';
+import mailRecipientRouter from './mail-recipient';
 import mailServerRouter from './mail-server';
 import manifestRouter from './manifest';
 import networkInterfaceRouter from './network-interface';
@@ -18,12 +20,14 @@ import userRouter from './user';
 
 const routes = {
   private: {
+    'alert-override': alertOverrideRouter,
     anvil: anvilRouter,
     command: commandRouter,
     fence: fenceRouter,
     file: fileRouter,
     host: hostRouter,
     job: jobRouter,
+    'mail-recipient': mailRecipientRouter,
     'mail-server': mailServerRouter,
     manifest: manifestRouter,
     'network-interface': networkInterfaceRouter,

--- a/striker-ui-api/src/routes/mail-recipient.ts
+++ b/striker-ui-api/src/routes/mail-recipient.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+
+import {
+  createMailRecipient,
+  deleteMailRecipient,
+  getMailRecipient,
+  getMailRecipientDetail,
+  updateMailRecipient,
+} from '../lib/request_handlers/mail-recipient';
+
+const router = express.Router();
+
+router
+  .delete('/:uuid', deleteMailRecipient)
+  .get('/', getMailRecipient)
+  .get('/:uuid', getMailRecipientDetail)
+  .post('/', createMailRecipient)
+  .put('/:uuid', updateMailRecipient);
+
+export default router;

--- a/striker-ui-api/src/routes/mail-server.ts
+++ b/striker-ui-api/src/routes/mail-server.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+
+import {
+  createMailServer,
+  deleteMailServer,
+  getMailServer,
+  getMailServerDetail,
+  updateMailServer,
+} from '../lib/request_handlers/mail-server';
+
+const router = express.Router();
+
+router
+  .delete('/:uuid', deleteMailServer)
+  .get('/', getMailServer)
+  .get('/:uuid', getMailServerDetail)
+  .post('/', createMailServer)
+  .put('/:uuid', updateMailServer);
+
+export default router;

--- a/striker-ui-api/src/types/ApiAlertOverride.d.ts
+++ b/striker-ui-api/src/types/ApiAlertOverride.d.ts
@@ -1,0 +1,21 @@
+type AlertOverrideOverview = {
+  level: number;
+  host: HostOverview;
+  mailRecipient: MailRecipientOverview;
+  uuid: string;
+};
+
+type AlertOverrideDetail = AlertOverrideOverview;
+
+type AlertOverrideOverviewList = {
+  [uuid: string]: AlertOverrideOverview;
+};
+
+type AlertOverrideParamsDictionary = {
+  uuid: string;
+};
+
+type AlertOverrideRequestBody = Pick<AlertOverrideDetail, 'level'> & {
+  hostUuid: string;
+  mailRecipientUuid: string;
+};

--- a/striker-ui-api/src/types/ApiAlertOverride.d.ts
+++ b/striker-ui-api/src/types/ApiAlertOverride.d.ts
@@ -11,7 +11,11 @@ type AlertOverrideOverviewList = {
   [uuid: string]: AlertOverrideOverview;
 };
 
-type AlertOverrideParamsDictionary = {
+type AlertOverrideReqQuery = {
+  'mail-recipient': string | string[];
+};
+
+type AlertOverrideReqParams = {
   uuid: string;
 };
 

--- a/striker-ui-api/src/types/ApiAlertOverride.d.ts
+++ b/striker-ui-api/src/types/ApiAlertOverride.d.ts
@@ -1,7 +1,8 @@
 type AlertOverrideOverview = {
   level: number;
-  host: HostOverview;
   mailRecipient: MailRecipientOverview;
+  node: { name: string; uuid: string };
+  subnode: { name: string; short: string; uuid: string };
   uuid: string;
 };
 

--- a/striker-ui-api/src/types/ApiMailRecipient.d.ts
+++ b/striker-ui-api/src/types/ApiMailRecipient.d.ts
@@ -18,3 +18,5 @@ type MailRecipientParamsDictionary = {
 };
 
 type MailRecipientRequestBody = Omit<MailRecipientDetail, 'uuid'>;
+
+type MailRecipientResponseBody = Pick<MailRecipientDetail, 'uuid'>;

--- a/striker-ui-api/src/types/ApiMailRecipient.d.ts
+++ b/striker-ui-api/src/types/ApiMailRecipient.d.ts
@@ -1,0 +1,20 @@
+type MailRecipientOverview = {
+  name: string;
+  uuid: string;
+};
+
+type MailRecipientDetail = MailRecipientOverview & {
+  email: string;
+  language: string;
+  level: number;
+};
+
+type MailRecipientOverviewList = {
+  [uuid: string]: MailRecipientOverview;
+};
+
+type MailRecipientParamsDictionary = {
+  uuid: string;
+};
+
+type MailRecipientRequestBody = Omit<MailRecipientDetail, 'uuid'>;

--- a/striker-ui-api/src/types/ApiMailServer.d.ts
+++ b/striker-ui-api/src/types/ApiMailServer.d.ts
@@ -1,0 +1,23 @@
+type MailServerOverview = {
+  address: string;
+  port: number;
+  uuid: string;
+};
+
+type MailServerDetail = MailServerOverview & {
+  authentication: string;
+  heloDomain: string;
+  password?: string;
+  security: string;
+  username?: string;
+};
+
+type MailServerOverviewList = {
+  [uuid: string]: MailServerOverview;
+};
+
+type MailServerParamsDictionary = {
+  uuid: string;
+};
+
+type MailServerRequestBody = Omit<MailServerDetail, 'uuid'>;


### PR DESCRIPTION
This PR adds the endpoints `/mail-server`, `/mail-recipient`, and `/alert-override` for configuring mail-related properties. It doesn't include a rebuild; that would be in the next PR.