### PR TITLE
Beta fixes - abort old shutdown commands

### DIFF
--- a/share/words.xml
+++ b/share/words.xml
@@ -2157,7 +2157,7 @@ The md5sum of: [#!variable!file!#] has changed since the daemon started.
 		<key name="log_0254">[ Warning ] - The Storage->make_directory() method failed to create the directory: [#!variable!directory!#].</key>
 		<key name="log_0255">[ Note ] - Created the directory: [#!variable!directory!#].</key>
 		<key name="log_0256">### POWER OFF REQUESTED ### - [#!variable!reason!#]</key>
-		<key name="log_0257">Stopping Anvil! daemons.</key>
+		<key name="log_0257">Stopping Scancore.</key>
 		<key name="log_0258">Syncing the file systems.</key>
 		<key name="log_0259">[ Note ] - Updating passwords on this host only.</key>
 		<key name="log_0260">No Anvil! nodes found, updates not required.</key>

--- a/share/words.xml
+++ b/share/words.xml
@@ -1787,13 +1787,13 @@ Note: This is a permanent action! If you protect this server again later, a full
 		<key name="job_0470">This is a DR host, no migration possible.</key>
 		<key name="job_0471">Exiting.</key>
 		<key name="job_0472">#!free!#</key>
-		<key name="job_0473">#!free!#</key>
+		<key name="job_0473">The request to power off this host is: [#!variable!age!#] seconds old. This is too old, so the request will be ignored to prevent unwanted power loss.</key>
 		<key name="job_0474">The server: [#!variable!server!#] will now be forced off!</key>
 		<key name="job_0475">The subnode: [#!variable!subnode!#] is not ready. Configured: [#!variable!configured!#], maintenance mode: [#!variable!maintenance_mode!#], job_running: [#!variable!job_running!#].</key>
 		<key name="job_0476">Waiting for a bit, then will check again.</key>
 		<key name="job_0477">Waiting for both subnodes to be configured and out of maintenance mode.</key>
 		<key name="job_0478">Preparing the new definition file</key>
-		<key name="job_0479">#!free!#</key>
+		<key name="job_0479">The request to power off the server: [#!variable!server!#] is: [#!variable!age!#] seconds old. This is too old, so the request will be ignored to prevent unwanted power loss.</key>
 		<key name="job_0480">Running as a job, not prompting the user to confirm.</key>
 		<key name="job_0481">The fence device: [#!variable!device!#] already exists.</key>
 		<key name="job_0482">Waiting for the peer's hostname to be: [#!variable!peer_name!#] in the database.</key>
@@ -2261,7 +2261,7 @@ Will now try with: [#!variable!count!#] known password(s).</key>
 		<key name="log_0341">[ Warning ] - Not all hosts are online, but '--force' was used!
 [ Warning ] - You will need to manually update the passwords using this tool with '--local' later.</key>
 		<key name="log_0342">Updating the VNC user: [#!variable!vncuser!#] password.</key>
-		<key name="log_0343">The request to power off the server is: [#!variable!age!#] seconds old. This is too old, so the request will be ignored to prevent unwanted power loss.</key>
+		<key name="log_0343">#!free!#</key>
 		<key name="log_0344">The server: [#!variable!server!#] wasn't found on this machine.</key>
 		<key name="log_0345">#!free!#</key>
 		<key name="log_0346">#!free!#</key>

--- a/share/words.xml
+++ b/share/words.xml
@@ -2261,7 +2261,7 @@ Will now try with: [#!variable!count!#] known password(s).</key>
 		<key name="log_0341">[ Warning ] - Not all hosts are online, but '--force' was used!
 [ Warning ] - You will need to manually update the passwords using this tool with '--local' later.</key>
 		<key name="log_0342">Updating the VNC user: [#!variable!vncuser!#] password.</key>
-		<key name="log_0343">#!free!#</key>
+		<key name="log_0343">The request to power off the server is: [#!variable!age!#] seconds old. This is too old, so the request will be ignored to prevent unwanted power loss.</key>
 		<key name="log_0344">The server: [#!variable!server!#] wasn't found on this machine.</key>
 		<key name="log_0345">#!free!#</key>
 		<key name="log_0346">#!free!#</key>

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -2191,7 +2191,9 @@ sub run_jobs
 			# once at a time. If two jobs of the same command exist, only one will be called.
 			if ($job_progress != 100)
 			{
-				if (exists $anvil->data->{sys}{started}{$short_command})
+				# The one exception is 'striker-initialize-host' as it's normal to run 
+				# multiple in parallel.
+				if ((exists $anvil->data->{sys}{started}{$short_command}) && ($short_command !~ /striker-initialize-host/))
 				{
 					# Skip it.
 					my $started_job = $anvil->data->{sys}{started}{$short_command};

--- a/tools/anvil-safe-stop
+++ b/tools/anvil-safe-stop
@@ -85,8 +85,10 @@ else
 if ($anvil->data->{switches}{'job-uuid'})
 {
 	# Load the job data.
+	$anvil->Job->get_job_details({debug => 2});
+	
+	# Clear the job, in case it was partially run before
 	$anvil->Job->clear();
-	$anvil->Job->get_job_details();
 	$anvil->Job->update_progress({
 		progress         => 1,
 		job_picked_up_by => $$, 
@@ -120,6 +122,27 @@ if ($anvil->data->{switches}{'job-uuid'})
 			}});
 		}
 	}
+	
+	# If the job is too old, abort.
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		"jobs::job_age" => $anvil->data->{jobs}{job_age}, 
+	}});
+	if (($anvil->data->{jobs}{job_age}) && ($anvil->data->{jobs}{job_age} > 120))
+	{
+		# Too old.
+		$anvil->Job->update_progress({
+			progress   => 100, 
+			job_status => "aborted", 
+			message    => "log_0343",
+			'print'    => 1, 
+			log_level  => 1, 
+			variables  => {
+				age => $anvil->data->{jobs}{job_age}, 
+			},
+		});
+		$anvil->nice_exit({exit_code => 0});
+	}
+	die;
 }
 
 # Make sure we're a subnode or DR host

--- a/tools/anvil-safe-stop
+++ b/tools/anvil-safe-stop
@@ -133,7 +133,7 @@ if ($anvil->data->{switches}{'job-uuid'})
 		$anvil->Job->update_progress({
 			progress   => 100, 
 			job_status => "aborted", 
-			message    => "log_0343",
+			message    => "job_0473",
 			'print'    => 1, 
 			log_level  => 1, 
 			variables  => {
@@ -142,7 +142,6 @@ if ($anvil->data->{switches}{'job-uuid'})
 		});
 		$anvil->nice_exit({exit_code => 0});
 	}
-	die;
 }
 
 # Make sure we're a subnode or DR host

--- a/tools/anvil-safe-stop
+++ b/tools/anvil-safe-stop
@@ -190,19 +190,15 @@ if ($anvil->data->{switches}{'power-off'})
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 3, list => { variable_uuid => $variable_uuid }});
 	}
 	
-	# Stop scancore and anvil-daemon.
+	# Stop scancore .
 	$anvil->Job->update_progress({
 		progress  => 90, 
 		log_level => 1, 
 		'print'   => 1, 
 		message   => "log_0257",
 	});
-	my $anvil_daemon_return_code = $anvil->System->stop_daemon({daemon => "anvil-daemon.service"});
-	my $scancore_return_code     = $anvil->System->stop_daemon({daemon => "scancore.service"});
-	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
-		anvil_daemon_return_code => $anvil_daemon_return_code,
-		scancore_return_code     => $scancore_return_code, 
-	}});
+	my $scancore_return_code = $anvil->System->stop_daemon({daemon => "scancore.service"});
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { scancore_return_code => $scancore_return_code }});
 	
 	# Sync the file systems
 	$anvil->Job->update_progress({

--- a/tools/anvil-shutdown-server
+++ b/tools/anvil-shutdown-server
@@ -74,11 +74,11 @@ $anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list
 if ($anvil->data->{switches}{'job-uuid'})
 {
 	# Load the job data.
-	$anvil->Job->clear();
 	$anvil->Job->get_job_details({
 		debug    => 2,
 		job_uuid => $anvil->data->{switches}{'job-uuid'},
 	});
+	$anvil->Job->clear();
 	$anvil->Job->update_progress({
 		progress         => 1,
 		job_picked_up_by => $$, 
@@ -109,6 +109,27 @@ if ($anvil->data->{switches}{'job-uuid'})
 				}});
 			}
 		}
+	}
+	
+	# If the job is too old, abort.
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { 
+		"jobs::job_age" => $anvil->data->{jobs}{job_age}, 
+	}});
+	if (($anvil->data->{jobs}{job_age}) && ($anvil->data->{jobs}{job_age} > 120))
+	{
+		# Too old.
+		$anvil->Job->update_progress({
+			progress   => 100, 
+			job_status => "aborted", 
+			message    => "job_0479",
+			'print'    => 1, 
+			log_level  => 1, 
+			variables  => {
+				age    => $anvil->data->{jobs}{job_age}, 
+				server => $anvil->Get->server_from_switch({server => $anvil->data->{switches}{server}}),
+			},
+		});
+		$anvil->nice_exit({exit_code => 0});
 	}
 }
 


### PR DESCRIPTION
This adds safety checks to not shut down a host or server is the request to shut down is more than 120 seconds old. This deals with stale-but-incomplete jobs in the DB from causing unwanted shutdowns.