### PR TITLE
Implement database listeners and make database notify on jobs change

### DIFF
--- a/Anvil/Tools/Database.pm
+++ b/Anvil/Tools/Database.pm
@@ -181,10 +181,19 @@ sub DESTROY
 {
 	my $self = shift;
 
+	my $listeners = $self->{listeners};
+
 	# Clean up all lingering database listeners
-	foreach my $notify_name (keys %{$self->{listeners}})
+	foreach my $forks (values %{$listeners})
 	{
-		$self->remove_listener({ name => $notify_name });
+		foreach my $fork (values %{$forks})
+		{
+			next if not $fork->poll();
+
+			print "Database listener with PID: [".$fork->pid."] exiting on DESTROY.\n";
+
+			$fork->kill() or $fork->kill("SIGKILL");
+		}
 	}
 }
 

--- a/Anvil/Tools/Database.pm
+++ b/Anvil/Tools/Database.pm
@@ -177,6 +177,17 @@ sub parent
 	return ($self->{HANDLE}{TOOLS});
 }
 
+sub DESTROY
+{
+	my $self = shift;
+
+	# Clean up all lingering database listeners
+	foreach my $notify_name (keys %{$self->{listeners}})
+	{
+		$self->remove_listener({ name => $notify_name });
+	}
+}
+
 
 #############################################################################################################
 # Public methods                                                                                            #

--- a/Anvil/Tools/Database.pm
+++ b/Anvil/Tools/Database.pm
@@ -297,7 +297,7 @@ sub add_listener
 		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
 	}
 
-	my $listen = eval { $dbh->do("LISTEN ".$trigger); };
+	my $listen = eval { $dbh->do("LISTEN ".$notify_name); };
 
 	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => $debug, list => { listen => $listen } });
 

--- a/share/anvil.sql
+++ b/share/anvil.sql
@@ -806,12 +806,12 @@ CREATE TABLE history.jobs (
 );
 ALTER TABLE history.jobs OWNER TO admin;
 
-CREATE FUNCTION history_jobs() RETURNS trigger
+CREATE OR REPLACE FUNCTION history_jobs() RETURNS trigger
 AS $$
 DECLARE
     history_jobs RECORD;
 BEGIN
-    SELECT INTO history_jobs * FROM jobs WHERE job_uuid = new.job_uuid;
+    SELECT INTO history_jobs * FROM jobs WHERE job_uuid = NEW.job_uuid;
     INSERT INTO history.jobs
         (job_uuid, 
          job_host_uuid, 
@@ -840,6 +840,7 @@ BEGIN
          history_jobs.job_description, 
          history_jobs.job_status, 
          history_jobs.modified_date);
+    PERFORM pg_notify('after_insert_or_update_job', row_to_json(NEW)::text);
     RETURN NULL;
 END;
 $$

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -347,11 +347,9 @@ sub handle_clone_database_connection_failure
 	my $anvil      = $parameters->{anvil};
 	my $responder  = $parameters->{responder};
 
-	print $responder "failed to clone primary database handle\n";
+	pstderr("failed to clone primary database handle");
 
 	$responder->shutdown(SHUT_RDWR);
-
-	$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
 }
 
 sub handle_responder_output_setup
@@ -435,14 +433,10 @@ sub handle_connections
 			responder => $responder,
 			server    => $server,
 		}) and do {
-			pstdout($$."::manage_database_listeners ended with true");
-
-			$responder->shutdown(SHUT_WR);
+			# Don't close the responder because it's being used by the listener to send data.
 
 			next;
 		};
-
-		pstdout($$."::manage_database_listeners ended with false");
 
 		my $response_process = Proc::Simple->new();
 
@@ -640,26 +634,46 @@ sub manage_database_listeners
 	{
 		my $name = $1;
 
-		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { name => $name } }); 
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { name => $name } });
+
+		my $handle_begin_child     = sub {
+			# Close the server because the child doesn't need it
+			close($server);
+
+			handle_responder_output_setup({ anvil => $anvil, responder => $responder })
+		};
+
+		my $handle_failed_to_clone = sub {
+			handle_clone_database_connection_failure({ anvil => $anvil, responder => $responder });
+		};
+
+		my $handle_failed_to_ping  = sub {
+			pstderr("failed to ping database");
+
+			$responder->shutdown(SHUT_RDWR);
+		};
+
+		my $handle_notify          = sub {
+			my $parameters = shift;
+			my $notify     = $parameters->{notify};
+
+			my ($name, $pid, $payload) = @$notify;
+
+			$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+				name    => $name,
+				pid     => $pid,
+				payload => $payload,
+			}, prefix => "handle_notify" });
+
+			pstdout($name.":".$pid.":".$payload);
+		};
 
 		my ($add_listener_code, $listener, $error) = $anvil->Database->add_listener({
 			debug              => 2,
 			name               => $name,
-			on_failed_to_clone => \&handle_clone_database_connection_failure,
-			on_begin_child     => sub {
-				# Close the server because the child doesn't need it
-				close($server);
-
-				handle_responder_output_setup({ anvil => $anvil, responder => $responder });
-			},
-			on_notify          => sub {
-				my $parameters = shift;
-				my $notify     = $parameters->{notify};
-
-				my ($name, $pid, $payload) = @$notify;
-
-				pstdout($name.":".$pid.":".$payload);
-			},
+			on_begin_child     => $handle_begin_child,
+			on_failed_to_clone => $handle_failed_to_clone,
+			on_notify          => $handle_notify,
 		});
 
 		if ($add_listener_code != 0)
@@ -983,6 +997,8 @@ sub run_responder
 	if (not $clone)
 	{
 		handle_clone_database_connection_failure({ anvil => $anvil, responder => $responder });
+
+		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
 	}
 
 	my @cmd_lines = split(/;;/, $line);

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -177,10 +177,10 @@ main();
 sub access_chain
 {
 	my $parameters = shift;
-	# required:
+	# Required:
 	my $anvil      = $parameters->{anvil};
 	my $chain_str  = $parameters->{chain};
-	# optional:
+	# Optional:
 	my $chain_args = $parameters->{chain_args} // [];
 
 	my @chain        = split(/->|[.]/, $chain_str);
@@ -266,10 +266,10 @@ sub access_chain
 sub db_access
 {
 	my $parameters = shift;
-	# required:
+	# Required:
 	my $anvil      = $parameters->{anvil};
 	my $sql        = $parameters->{sql};
-	# optional:
+	# Optional:
 	my $mode       = $parameters->{db_access_mode} // "";
 	my $uuid       = $parameters->{db_uuid};
 
@@ -311,11 +311,11 @@ sub emit
 sub get_scmd_args
 {
 	my $parameters = shift;
-	# required:
+	# Required:
 	my $anvil      = $parameters->{anvil};
 	my $input      = $parameters->{input};
 	my $get_values = $parameters->{get_values};
-	# optional:
+	# Optional:
 	my $cmd        = $parameters->{cmd};
 	my $arg_names  = $parameters->{names} // [];
 
@@ -394,7 +394,17 @@ sub handle_connections
 
 	emit("listening");
 
+	my $emit_listener_event  = sub { emit("dbl:".($_[1] // $$)."-".$_[0]); };
+	my $emit_responder_event = sub { emit("responder:".($_[1] // $$)."-".$_[0]); };
+
 	while (my $responder = $server->accept() or do {
+		#
+		# Ignore interrupt caused by auto SIGCHLD in the reaper of Proc::Simple.
+		#
+		# accept() will fail with $! set to "Interrupted system call" without ignoring the interrupt caused by SIGCHLD.
+		#
+		next if $!{EINTR};
+
 		pstderr("failed to accept connections; cause: ".$!);
 
 		close($server);
@@ -404,10 +414,10 @@ sub handle_connections
 	{
 		my $request_line = <$responder>;
 
-		chomp($request_line);
-
 		# Responder is done reading
 		$responder->shutdown(SHUT_RD);
+
+		chomp($request_line);
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { request_line => $request_line } });
 
@@ -417,8 +427,6 @@ sub handle_connections
 
 			last;
 		}
-
-		my $emit_listener_event = sub { emit("dbl:".($_[1] // $$)."-".$_[0]); };
 
 		manage_database_listeners({
 			anvil     => $anvil,
@@ -435,8 +443,6 @@ sub handle_connections
 		};
 
 		pstdout($$."::manage_database_listeners ended with false");
-
-		my $emit_responder_event = sub { emit("responder:".($_[1] // $$)."-".$_[0]); };
 
 		my $response_process = Proc::Simple->new();
 
@@ -800,9 +806,6 @@ sub run_interface
 	my $server      = $parameters->{server};
 	my $socket_path = $parameters->{socket_path};
 
-	return (0) if (not $anvil);
-	return (0) if (not $server);
-
 	my $script_file = $anvil->data->{switches}{'script'} // "-";
 
 	# Close the server because the child doesn't need it.
@@ -915,9 +918,6 @@ sub run_requester
 	my $script_fh   = $parameters->{script_fh};
 	my $script_line = $parameters->{script_line};
 	my $socket_path = $parameters->{socket_path};
-
-	return (0) if (not $anvil);
-	return (0) if (not $script_fh);
 
 	# The child doesn't need to process input.
 	close($script_fh);

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -619,6 +619,8 @@ sub handle_connections
 	{
 		my $request_line = <$responder>;
 
+		chomp($request_line);
+
 		# responder is done reading
 		$responder->shutdown(SHUT_RD);
 
@@ -851,6 +853,8 @@ sub main
 
 	while (my $script_line = <$script_file_handle>)
 	{
+		chomp($script_line);
+
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { script_line => $script_line } });
 
 		if ($script_line =~ /^(?:q|quit)\s*$/)

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -882,7 +882,7 @@ sub run_interface
 			last;
 		}
 
-		local $emit_requester_event = sub { emit("requester:".($_[1] // $$)."-".$_[0]); };
+		my $emit_requester_event = sub { emit("requester:".($_[1] // $$)."-".$_[0]); };
 
 		my $request_process = Proc::Simple->new();
 

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -163,7 +163,6 @@ my $running_directory   =  ($0 =~ /^(.*?)\/$THIS_FILE$/)[0];
 
 $running_directory =~ s/^\./$ENV{PWD}/ if $running_directory =~ /^\./ && $ENV{PWD};
 
-my $scmd_db_listen = "listen";
 my $scmd_db_read   = "r";
 my $scmd_db_write  = "w";
 my $scmd_execute   = "x";
@@ -281,7 +280,6 @@ sub check_database_handles
 
 		if ((not exists $dbh) or (not $dbh) or (not $dbh->ping))
 		{
-			# ignore broken database handle(s)
 			next;
 		}
 
@@ -419,6 +417,7 @@ sub get_scmd_args
 sub handle_connections
 {
 	my $parameters = shift;
+	# required:
 	my $anvil      = $parameters->{anvil};
 	my $server     = $parameters->{server};
 
@@ -556,10 +555,6 @@ sub handle_connections
 			{
 				process_scmd_execute({ anvil => $anvil, input => $cmd_line, lid => $cmd_line_id });
 			}
-			elsif ($cmd_line =~ /^$scmd_db_listen\s+/)
-			{
-				# it's a request to register a listener to a database trigger
-			}
 		}
 
 		# responder is done writing
@@ -647,7 +642,9 @@ sub main
 
 	if ($daemonize)
 	{
-		return handle_connections({ anvil => $anvil, server => $server });
+		handle_connections({ anvil => $anvil, server => $server });
+		# when running as daemon, the main process shouldn't do anything other than handling connections
+		return;
 	}
 
 	# make 1 child to interact on stdio
@@ -667,6 +664,8 @@ sub main
 		emit("interface:".$interface_pid."-forked");
 
 		handle_connections({ anvil => $anvil, server => $server });
+		# after starting a child process to handle the stdin interactions, the main process should only handle connections
+		return;
 	}
 
 	#############

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -472,11 +472,11 @@ sub manage_database_listeners
 
 	if ($input =~ s/^list//)
 	{
-		foreach my $trigger (sort { $a cmp $b } keys %{$db_listeners})
+		foreach my $notify_name (sort { $a cmp $b } keys %{$db_listeners})
 		{
-			my $pid = $db_listeners->{$trigger};
+			my $pid = $db_listeners->{$notify_name};
 
-			pstdout($trigger.":".$pid);
+			pstdout($notify_name.":".$pid);
 		}
 
 		return 1;
@@ -495,9 +495,9 @@ sub manage_database_listeners
 
 	if ($input =~ s/^add\s+(\w+)//)
 	{
-		my $trigger = $1;
+		my $notify_name = $1;
 
-		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { trigger => $trigger } });
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { notify_name => $notify_name } });
 
 		my $clone_fail_handler = \&handle_database_clone_connection_failure;
 
@@ -519,7 +519,7 @@ sub manage_database_listeners
 
 		my ($add_listener_code, $pid, $error) = $anvil->Database->add_listener({
 			debug            => 2,
-			name             => $trigger,
+			name             => $notify_name,
 			on_clone_fail    => $clone_fail_handler,
 			on_fork_child    => $fork_child_handler,
 			on_notify        => $notify_handler,
@@ -531,6 +531,8 @@ sub manage_database_listeners
 
 			return 0;
 		}
+
+		$db_listeners->{$notify_name} = $pid;
 
 		emit("db-listener:".$pid."-forked");
 

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -842,9 +842,9 @@ sub run_interface
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { script_file => $script_file } });
 
-		if ($script_file =~ /^-$/)
+		if ($script_file eq "-")
 		{
-			open($script_file_handle, "-");
+			open($script_file_handle, $script_file);
 		}
 		else
 		{
@@ -955,7 +955,7 @@ sub run_requester
 
 	$emit->("exit");
 
-	# Same; don't close because the cache is pointing to the original connection(s).
+	# Same; don't disconnect because the cache is pointing to the original connection(s).
 	$anvil->nice_exit({ db_disconnect => 0, exit_code => 0 });
 }
 

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -387,9 +387,29 @@ sub emit
 	pstdout("event=".$_[0]);
 }
 
-#
-# this subroutine should only run in the main process
-#
+sub exit_responder
+{
+	my $parameters = shift;
+	# required:
+	my $anvil      = $parameters->{anvil};
+	my $responder  = $parameters->{responder};
+
+	emit("responder:".$$."-exit");
+
+	# responder is done writing
+	$responder->shutdown(SHUT_WR);
+
+	$anvil->nice_exit({ exit_code => 0 });
+
+	#############
+	#### END #### responder block
+	#############
+}
+
+# notes:
+# - this subroutine should only run in the main process
+# - every line after the call to this function are a part of the responder process
+# - calling this subroutine requires calling exit_responder later for clean up
 sub fork_responder
 {
 	my $parameters = shift;
@@ -497,9 +517,7 @@ sub get_scmd_args
 	return $args;
 }
 
-#
 # this subroutine should only run in the main process
-#
 sub manage_database_listeners
 {
 	my $parameters = shift;
@@ -549,11 +567,7 @@ sub manage_database_listeners
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { trigger => $trigger } });
 
-		fork_responder({
-			anvil     => $anvil,
-			responder => $responder,
-			server    => $server,
-		}) or do {
+		fork_responder({ anvil => $anvil, responder => $responder, server => $server }) or do {
 			return 1;
 		};
 
@@ -574,7 +588,7 @@ sub manage_database_listeners
 			emit($name.":".$pid.":".$payload);
 		}
 
-		return 1;
+		exit_responder({ anvil => $anvil, responder => $responder });
 	}
 }
 
@@ -642,11 +656,7 @@ sub handle_connections
 
 		pstdout($$."::manage_database_listeners ended with false");
 
-		fork_responder({
-			anvil     => $anvil,
-			responder => $responder,
-			server    => $server,
-		}) or do {
+		fork_responder({ anvil => $anvil, responder => $responder, server => $server }) or do {
 			pstdout($$."::fork_responder ended with false");
 
 			next;
@@ -687,16 +697,7 @@ sub handle_connections
 			}
 		}
 
-		emit("responder:".$$."-exit");
-
-		# responder is done writing
-		$responder->shutdown(SHUT_WR);
-
-		$anvil->nice_exit({ exit_code => 0 });
-
-		#############
-		#### END #### responder block
-		#############
+		exit_responder({ anvil => $anvil, responder => $responder });
 	}
 
 	close($server);

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -402,7 +402,7 @@ sub fork_responder
 		pstderr("no usable database handle");
 
 		return 0;
-	}
+	};
 
 	my $pid = fork;
 
@@ -460,7 +460,7 @@ sub fork_responder
 		$responder->shutdown(SHUT_RDWR);
 
 		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
-	}
+	};
 
 	return 1;
 }

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -597,7 +597,7 @@ sub manage_database_listeners
 
 	if ($input =~ s/^list//)
 	{
-		my $listeners = $anvil->Database->listeners;
+		my $listeners = $anvil->Database->{listeners};
 
 		foreach my $name (sort { $a cmp $b } keys %{$listeners})
 		{

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -642,7 +642,7 @@ sub manage_database_listeners
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { name => $name } }); 
 
-		my ($add_listener_code, $pid, $error) = $anvil->Database->add_listener({
+		my ($add_listener_code, $listener, $error) = $anvil->Database->add_listener({
 			debug              => 2,
 			name               => $name,
 			on_failed_to_clone => \&handle_clone_database_connection_failure,
@@ -669,7 +669,7 @@ sub manage_database_listeners
 			return 0;
 		}
 
-		$emit->("forked", $pid);
+		$emit->("forked", $listener->pid);
 
 		return 1;
 	}

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -263,40 +263,6 @@ sub access_chain
 	return (@results);
 }
 
-sub check_database_handles
-{
-	my $parameters = shift;
-	my $anvil      = $parameters->{anvil};
-
-	my $success = 0;
-
-	foreach my $uuid (sort { $a cmp $b } keys %{$anvil->data->{database}})
-	{
-		if (not exists $anvil->data->{cache}{database_handle}{$uuid})
-		{
-			next;
-		}
-
-		my $dbh = $anvil->data->{cache}{database_handle}{$uuid};
-
-		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
-			database_uuid => $uuid,
-			dbh_local     => $dbh,
-		} });
-
-		if ((not $dbh) or (not $dbh->ping))
-		{
-			next;
-		}
-
-		$success += 1;
-	}
-
-	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { success => $success }, prefix => "check_database_handles" });
-
-	return $success;
-}
-
 sub db_access
 {
 	my $parameters = shift;
@@ -342,86 +308,6 @@ sub emit
 	pstdout("event=".$_[0]);
 }
 
-#
-# this subroutine cleans up the fork made by fork_response_process()
-#
-sub exit_response_process
-{
-	my $parameters = shift;
-	# required:
-	my $anvil     = $parameters->{anvil};
-	my $responder = $parameters->{responder};
-
-	emit("responder:".$$."-exit");
-
-	# responder is done writing
-	$responder->shutdown(SHUT_WR);
-
-	$anvil->nice_exit({ exit_code => 0 });
-
-	#############
-	#### END #### response process block
-	#############
-}
-
-#
-# this subroutine should only run in the main process
-#
-# every line after the call to this function are a part of the responder process
-#
-sub fork_response_process
-{
-	my $parameters = shift;
-	# required:
-	my $anvil      = $parameters->{anvil};
-	my $responder  = $parameters->{responder};
-	my $server     = $parameters->{server};
-
-	check_database_handles({ anvil => $anvil }) or do {
-		pstderr("no usable database handle");
-
-		return 0;
-	};
-
-	my $pid = fork;
-
-	if (not defined $pid)
-	{
-		pstderr("failed to fork on receive; cause: ".$!);
-
-		return 0;
-	}
-
-	if ($pid)
-	{
-		emit("responder:".$pid."-forked");
-
-		return 0;
-	}
-
-	#############
-	### BEGIN ### response process block
-	#############
-
-	# close the server because the child doesn't need it
-	close($server);
-
-	handle_responder_output_setup({ anvil => $anvil, responder => $responder });
-
-	# clone the database handle for this child to avoid interfering with another process that needs to use the database
-	#
-	# the database handle variable only holds a reference to the parent's database handle before clone completes, therefore we shouldn't call disconnect unless clone succeeds
-
-	my ($clone_connection_code, $clone) = $anvil->Database->clone_connection({ debug => 2 });
-
-	if (not $clone)
-	{
-		handle_database_clone_connection_failure({ anvil => $anvil, responder => $responder });
-	}
-
-	return 1;
-}
-
 sub get_scmd_args
 {
 	my $parameters = shift;
@@ -454,101 +340,10 @@ sub get_scmd_args
 	return $args;
 }
 
-# this subroutine should only run in the main process
-sub manage_database_listeners
+sub handle_clone_database_connection_failure
 {
 	my $parameters = shift;
-	# required:
-	my $anvil        = $parameters->{anvil};
-	my $db_listeners = $parameters->{db_listeners};
-	my $input        = $parameters->{input};
-	my $responder    = $parameters->{responder};
-	my $server       = $parameters->{server};
-
-	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { input => $input }, prefix => "manage_database_listeners" });
-
-	# ignore because it's not a database listener action
-	if (not ($input =~ s/^\s*dbl:://))
-	{
-		return 0;
-	}
-
-	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { input => $input } });
-
-	if ($input =~ s/^list//)
-	{
-		foreach my $notify_name (sort { $a cmp $b } keys %{$db_listeners})
-		{
-			my $pid = $db_listeners->{$notify_name};
-
-			pstdout($notify_name.":".$pid);
-		}
-
-		return 1;
-	}
-
-	if ($input =~ s/^remove\s+(\d+)//)
-	{
-		my $pid = $1;
-
-		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { pid => $pid } });
-
-		kill('TERM', $pid);
-
-		return 1;
-	}
-
-	if ($input =~ s/^add\s+(\w+)//)
-	{
-		my $notify_name = $1;
-
-		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { notify_name => $notify_name } });
-
-		my $clone_fail_handler = \&handle_database_clone_connection_failure;
-
-		my $fork_child_handler = sub {
-			# close the server because the child doesn't need it
-			close($server);
-
-			handle_responder_output_setup({ anvil => $anvil, responder => $responder });
-		};
-
-		my $notify_handler = sub {
-			my $params = shift;
-			my $notify = $params->{notify};
-
-			my ($n_name, $n_pid, $n_payload) = @$notify;
-
-			emit($n_name.":".$n_pid.":".$n_payload);
-		};
-
-		my ($add_listener_code, $pid, $error) = $anvil->Database->add_listener({
-			debug            => 2,
-			name             => $notify_name,
-			on_clone_fail    => $clone_fail_handler,
-			on_fork_child    => $fork_child_handler,
-			on_notify        => $notify_handler,
-		});
-
-		if ($add_listener_code != 0)
-		{
-			pstdout("failed to fork on receive; cause: ".$error);
-
-			return 0;
-		}
-
-		$db_listeners->{$notify_name} = $pid;
-
-		emit("db-listener:".$pid."-forked");
-
-		return 1;
-	}
-}
-
-sub handle_database_clone_connection_failure
-{
-	my $parameters = shift;
-	# required:
+	# Required:
 	my $anvil      = $parameters->{anvil};
 	my $responder  = $parameters->{responder};
 
@@ -562,16 +357,16 @@ sub handle_database_clone_connection_failure
 sub handle_responder_output_setup
 {
 	my $parameters = shift;
-	# required:
+	# Required:
 	my $anvil      = $parameters->{anvil};
 	my $responder  = $parameters->{responder};
 
-	# disconnect from the parent's outputs to avoid interference
+	# Disconnect from the parent's outputs to avoid interference
 
 	close(STDOUT);
 	close(STDERR);
 
-	# redirect outputs to the responder for transport
+	# Redirect outputs to the responder for transport
 
 	open(STDOUT, ">&", $responder) or do {
 		print $responder "failed to open STDOUT; cause: ".$!."\n";
@@ -593,31 +388,9 @@ sub handle_responder_output_setup
 sub handle_connections
 {
 	my $parameters = shift;
-	# required:
+	# Required:
 	my $anvil      = $parameters->{anvil};
 	my $server     = $parameters->{server};
-
-	my $database_listeners = {};
-
-	local $SIG{INT}  = sub {
-		emit("sigint");
-
-		close($server);
-
-		emit("exit");
-
-		$anvil->catch_sig({ signal => "INT" });
-	};
-
-	local $SIG{TERM} = sub {
-		emit("sigterm");
-
-		close($server);
-
-		emit("exit");
-
-		$anvil->catch_sig({ signal => "TERM" });
-	};
 
 	emit("listening");
 
@@ -633,19 +406,26 @@ sub handle_connections
 
 		chomp($request_line);
 
-		# responder is done reading
+		# Responder is done reading
 		$responder->shutdown(SHUT_RD);
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { request_line => $request_line } });
 
-		last if ($request_line =~ /^(?:q|quit)\s*$/);
+		if ($request_line =~ /^(?:q|quit)\s*$/)
+		{
+			$responder->shutdown(SHUT_WR);
+
+			last;
+		}
+
+		my $emit_listener_event = sub { emit("dbl:".($_[1] // $$)."-".$_[0]); };
 
 		manage_database_listeners({
-			anvil        => $anvil,
-			db_listeners => $database_listeners,
-			input        => $request_line,
-			responder    => $responder,
-			server       => $server,
+			anvil     => $anvil,
+			emit      => $emit_listener_event,
+			input     => $request_line,
+			responder => $responder,
+			server    => $server,
 		}) and do {
 			pstdout($$."::manage_database_listeners ended with true");
 
@@ -656,57 +436,28 @@ sub handle_connections
 
 		pstdout($$."::manage_database_listeners ended with false");
 
-		fork_response_process({ anvil => $anvil, responder => $responder, server => $server }) or do {
-			pstdout($$."::fork_response_process ended with false");
+		my $emit_responder_event = sub { emit("responder:".($_[1] // $$)."-".$_[0]); };
+
+		my $response_process = Proc::Simple->new();
+
+		$response_process->start(\&run_responder, {
+			anvil     => $anvil,
+			emit      => $emit_responder_event,
+			line      => $request_line,
+			responder => $responder,
+			server    => $server,
+		}) or do {
+			pstderr("failed to fork on receive; cause: ".$!);
 
 			$responder->shutdown(SHUT_WR);
 
 			next;
 		};
 
-		pstdout($$."::fork_response_process ended with true");
-
-		my @cmd_lines = split(/;;/, $request_line);
-
-		foreach my $cmd_line (@cmd_lines)
-		{
-			$cmd_line =~ s/^\s+//;
-			$cmd_line =~ s/\s+$//;
-
-			my $cmd_line_id;
-
-			if ($cmd_line =~ s/^([[:xdigit:]]{8}-(?:[[:xdigit:]]{4}-){3}[[:xdigit:]]{12})\s+//)
-			{
-				$cmd_line_id = $1;
-			}
-
-			$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
-				cmd_line    => $cmd_line,
-				cmd_line_id => $cmd_line_id,
-			} });
-
-			if ($cmd_line =~ /^$scmd_db_read\s+/)
-			{
-				process_scmd_db({ anvil => $anvil, cmd => $scmd_db_read, input => $cmd_line, lid => $cmd_line_id });
-			}
-			elsif ($cmd_line =~ /^$scmd_db_write\s+/)
-			{
-				process_scmd_db({ anvil => $anvil, cmd => $scmd_db_write, input => $cmd_line, lid => $cmd_line_id });
-			}
-			elsif ($cmd_line =~ /^$scmd_execute\s+/)
-			{
-				process_scmd_execute({ anvil => $anvil, input => $cmd_line, lid => $cmd_line_id });
-			}
-		}
-
-		exit_response_process({ anvil => $anvil, responder => $responder });
+		$emit_responder_event->("forked", $response_process->pid);
 	}
 
-	close($server);
-
-	emit("exit");
-
-	$anvil->nice_exit({ exit_code => 0 });
+	return 1;
 }
 
 sub is_array
@@ -770,44 +521,154 @@ sub main
 		$anvil->nice_exit({ exit_code => 1 });
 	};
 
-	# Make child processes start-and-forget because we don't need to wait for them
-	local $SIG{CHLD} = "IGNORE";
-
-	if ($daemonize)
+	if (not $daemonize)
 	{
-		# When running as daemon, the main process shouldn't do anything other than handling connections
-		handle_connections({ anvil => $anvil, server => $server });
+		my $emit_interface_event = sub { emit("interface:".$$."-".$_[0]); };
+
+		my $interface_process = Proc::Simple->new();
+
+		$interface_process->start(\&run_interface, {
+			anvil       => $anvil,
+			emit        => $emit_interface_event,
+			server      => $server,
+			socket_path => $socket_path,
+		}) or do {
+			pstderr("failed to fork IO interface; cause: ". $!);
+
+			close($server);
+
+			$anvil->nice_exit({ exit_code => 1 });
+		};
+
+		$emit_interface_event->("forked");
+	}
+
+	local $SIG{INT}  = sub {
+		emit("sigint");
 
 		close($server);
 
-		$anvil->nice_exit({ exit_code => 0 });
-	}
+		emit("exit");
 
-	my $interface_emitter = sub { emit("interface:".$$."-".$_[0]); };
+		$anvil->catch_sig({ signal => "INT" });
+	};
 
-	my $interface = Proc::Simple->new();
-
-	my $forked = $interface->start(\&run_interface, {
-		anvil       => $anvil,
-		emit        => $interface_emitter,
-		server      => $server,
-		socket_path => $socket_path,
-	});
-
-	if (not $forked)
-	{
-		pstderr("failed to fork IO interface; cause: ". $!);
+	local $SIG{TERM} = sub {
+		emit("sigterm");
 
 		close($server);
 
-		$anvil->nice_exit({ exit_code => 1 });
-	}
+		emit("exit");
 
-	$interface_emitter->("forked");
+		$anvil->catch_sig({ signal => "TERM" });
+	};
 
+	# The main process shouldn't do anything other than handling connections.
 	handle_connections({ anvil => $anvil, server => $server });
 
+	close($server);
+
+	emit("exit");
+
 	$anvil->nice_exit({ exit_code => 0 });
+}
+
+sub manage_database_listeners
+{
+	my $parameters = shift;
+	# Required:
+	my $anvil      = $parameters->{anvil};
+	my $emit       = $parameters->{emit};
+	my $input      = $parameters->{input};
+	my $responder  = $parameters->{responder};
+	my $server     = $parameters->{server};
+
+	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { input => $input }, prefix => "manage_database_listeners" });
+
+	chomp($input);
+
+	# Ignore because it's not a database listener action
+	if (not ($input =~ s/^dbl:://))
+	{
+		return 0;
+	}
+
+	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { input => $input } });
+
+	if ($input =~ s/^list//)
+	{
+		my $listeners = $anvil->Database->listeners;
+
+		foreach my $name (sort { $a cmp $b } keys %{$listeners})
+		{
+			foreach my $pid (sort { $a cmp $b } keys %{$listeners->{$name}})
+			{
+				pstdout($name.":".$pid);
+			}
+		}
+
+		return 1;
+	}
+
+	if ($input =~ s/^remove\s+(\w+)//)
+	{
+		my $name = $1;
+
+		chomp($input);
+
+		my $pid;
+
+		if ($input =~ s/^(\d+)//)
+		{
+			$pid = $2;
+		}
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { name => $name, pid => $pid } });
+
+		$anvil->Database->remove_listener({ name => $name, pid => $pid });
+
+		return 1;
+	}
+
+	if ($input =~ s/^add\s+(\w+)//)
+	{
+		my $name = $1;
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { name => $name } }); 
+
+
+
+		my ($add_listener_code, $pid, $error) = $anvil->Database->add_listener({
+			debug              => 2,
+			name               => $name,
+			on_failed_to_clone => \&handle_clone_database_connection_failure,
+			on_begin_child     => sub {
+				# Close the server because the child doesn't need it
+				close($server);
+
+				handle_responder_output_setup({ anvil => $anvil, responder => $responder });
+			},
+			on_notify          => sub {
+				my $parameters = shift;
+				my $notify     = $parameters->{notify};
+
+				my ($name, $pid, $payload) = @$notify;
+
+				pstdout($name.":".$pid.":".$payload);
+			},
+		});
+
+		if ($add_listener_code != 0)
+		{
+			pstdout("failed to fork on receive; cause: ".$error);
+
+			return 0;
+		}
+
+		$emit->("forked");
+
+		return 1;
+	}
 }
 
 sub prettify
@@ -825,11 +686,11 @@ sub prettify
 sub process_scmd_db
 {
 	my $parameters = shift;
-	# required:
+	# Required:
 	my $anvil      = $parameters->{anvil};
 	my $cmd        = $parameters->{cmd};
 	my $input      = $parameters->{input};
-	# optional:
+	# Optional:
 	my $lid        = $parameters->{lid} // "";
 
 	my $mode;
@@ -874,10 +735,10 @@ sub process_scmd_db
 sub process_scmd_execute
 {
 	my $parameters = shift;
-	# required:
+	# Required:
 	my $anvil      = $parameters->{anvil};
 	my $input      = $parameters->{input};
-	# optional:
+	# Optional:
 	my $lid        = $parameters->{lid} // "";
 
 	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
@@ -1021,19 +882,23 @@ sub run_interface
 			last;
 		}
 
-		local $requester_emitter = sub { emit("requester:".$$."-".$_[0]); };
+		local $emit_requester_event = sub { emit("requester:".($_[1] // $$)."-".$_[0]); };
 
-		my $requester = Proc::Simple->new();
+		my $request_process = Proc::Simple->new();
 
-		$requester->start(\&run_requester, {
+		$request_process->start(\&run_requester, {
 			anvil       => $anvil,
-			emit        => $requester_emitter,
+			emit        => $emit_requester_event,
 			script_fh   => $script_file_handle,
 			script_line => $script_line,
 			socket_path => $socket_path,
-		});
+		}) or do {
+			pstderr("failed to fork requester; cause: ". $!);
 
-		$requester_emitter->("forked");
+			next;
+		};
+
+		$emit_requester_event->("forked", $request_process->pid);
 	}
 
 	close($script_file_handle);
@@ -1094,4 +959,71 @@ sub run_requester
 
 	# Same; don't close because the cache is pointing to the original connection(s).
 	$anvil->nice_exit({ db_disconnect => 0, exit_code => 0 });
+}
+
+sub run_responder
+{
+	my $parameters = shift;
+	# Required:
+	my $anvil      = $parameters->{anvil};
+	my $emit       = $parameters->{emit};
+	my $line       = $parameters->{line};
+	my $responder  = $parameters->{responder};
+	my $server     = $parameters->{server};
+
+	# Close the server because the child doesn't need it
+	close($server);
+
+	handle_responder_output_setup({ anvil => $anvil, responder => $responder });
+
+	# Clone the database handle for this child to avoid interfering with another process that needs to use the database
+	#
+	# The database handle variable only holds a reference to the parent's database handle before clone completes, therefore we shouldn't call disconnect unless clone succeeds
+
+	my ($clone_connection_code, $clone) = $anvil->Database->clone_connection({ debug => 2 });
+
+	if (not $clone)
+	{
+		handle_clone_database_connection_failure({ anvil => $anvil, responder => $responder });
+	}
+
+	my @cmd_lines = split(/;;/, $line);
+
+	foreach my $cmd_line (@cmd_lines)
+	{
+		$cmd_line =~ s/^\s+//;
+		$cmd_line =~ s/\s+$//;
+
+		my $cmd_line_id;
+
+		if ($cmd_line =~ s/^([[:xdigit:]]{8}-(?:[[:xdigit:]]{4}-){3}[[:xdigit:]]{12})\s+//)
+		{
+			$cmd_line_id = $1;
+		}
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+			cmd_line    => $cmd_line,
+			cmd_line_id => $cmd_line_id,
+		} });
+
+		if ($cmd_line =~ /^$scmd_db_read\s+/)
+		{
+			process_scmd_db({ anvil => $anvil, cmd => $scmd_db_read, input => $cmd_line, lid => $cmd_line_id });
+		}
+		elsif ($cmd_line =~ /^$scmd_db_write\s+/)
+		{
+			process_scmd_db({ anvil => $anvil, cmd => $scmd_db_write, input => $cmd_line, lid => $cmd_line_id });
+		}
+		elsif ($cmd_line =~ /^$scmd_execute\s+/)
+		{
+			process_scmd_execute({ anvil => $anvil, input => $cmd_line, lid => $cmd_line_id });
+		}
+	}
+
+	$emit->("exit");
+
+	# Responder is done writing
+	$responder->shutdown(SHUT_WR);
+
+	$anvil->nice_exit({ exit_code => 0 });
 }

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -636,7 +636,7 @@ sub manage_database_listeners
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { name => $name } });
 
-		my $handle_begin_child     = sub {
+		my $handle_child_forked    = sub {
 			# Close the server because the child doesn't need it
 			close($server);
 
@@ -665,20 +665,35 @@ sub manage_database_listeners
 				payload => $payload,
 			}, prefix => "handle_notify" });
 
-			pstdout($name.":".$pid.":".$payload);
+			$emit->($name.":".$payload);
+		};
+
+		local $SIG{INT}  = sub {
+			$emit->("sigint");
+			$emit->("exit");
+
+			$anvil->catch_sig({ signal => "INT" });
+		};
+
+		local $SIG{TERM} = sub {
+			$emit->("sigterm");
+			$emit->("exit");
+
+			$anvil->catch_sig({ signal => "TERM" });
 		};
 
 		my ($add_listener_code, $listener, $error) = $anvil->Database->add_listener({
 			debug              => 2,
 			name               => $name,
-			on_begin_child     => $handle_begin_child,
+			on_child_forked    => $handle_child_forked,
 			on_failed_to_clone => $handle_failed_to_clone,
+			on_failed_to_ping  => $handle_failed_to_ping,
 			on_notify          => $handle_notify,
 		});
 
 		if ($add_listener_code != 0)
 		{
-			pstdout("failed to fork on receive; cause: ".$error);
+			pstderr("failed to fork on receive; cause: ".$error);
 
 			return 0;
 		}

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -506,7 +506,7 @@ sub manage_database_listeners
 			close($server);
 
 			handle_responder_output_setup({ anvil => $anvil, responder => $responder });
-		}
+		};
 
 		my $notify_handler = sub {
 			my $params = shift;

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -163,9 +163,10 @@ my $running_directory   =  ($0 =~ /^(.*?)\/$THIS_FILE$/)[0];
 
 $running_directory =~ s/^\./$ENV{PWD}/ if $running_directory =~ /^\./ && $ENV{PWD};
 
-my $scmd_db_read  = "r";
-my $scmd_db_write = "w";
-my $scmd_execute  = "x";
+my $scmd_db_listen = "listen";
+my $scmd_db_read   = "r";
+my $scmd_db_write  = "w";
+my $scmd_execute   = "x";
 
 main();
 
@@ -262,28 +263,62 @@ sub access_chain
 	return (@results);
 }
 
+sub check_database_handles
+{
+	my $parameters = shift;
+	my $anvil      = $parameters->{anvil};
+
+	my $success_count = 0;
+
+	foreach my $uuid (sort { $a cmp $b } keys %{$anvil->data->{database}})
+	{
+		my $dbh = $anvil->data->{cache}{database_handle}{$uuid};
+
+		if ((not exists $dbh) or (not $dbh) or (not $dbh->ping))
+		{
+			# ignore broken database handle(s)
+			next;
+		}
+
+		$success_count += 1;
+	}
+
+	return $success_count;
+}
+
 # only used by child processes to clone the parent's database handles
 sub clone_database_handles
 {
 	my $parameters = shift;
 	my $anvil      = $parameters->{anvil};
 
+	my $success_count = 0;
+
 	foreach my $uuid (sort { $a cmp $b } keys %{$anvil->data->{database}})
 	{
-		if ((not exists $anvil->data->{cache}{database_handle}{$uuid}) or (not $anvil->data->{cache}{database_handle}{$uuid}))
-		{
-			# Useless handle, skip it.
-			next;
-		}
 		# get the copied parent's database handle, which was made when fork()
 		my $dbh = $anvil->data->{cache}{database_handle}{$uuid};
+
+		my $child_dbh;
+
 		# clone the parent's database handle for child use
-		my $child_dbh = $dbh->clone();
+		my $success = eval { $child_dbh = $dbh->clone(); };
+
+		if (not $success)
+		{
+			# failed to clone the parent's database handle; skip it
+			next;
+		}
+
 		# destroy the copied parent's dbh; this will not close the parent's original database handle because auto_inactive_destroy is set
 		undef $anvil->data->{cache}{database_handle}{$uuid};
 		# add the cloned child's dbh
 		$anvil->data->{cache}{database_handle}{$uuid} = $child_dbh;
+
+		$success_count += 1;
 	}
+
+	return $success_count;
 }
 
 sub db_access
@@ -408,6 +443,12 @@ sub handle_connections
 
 		last if ($request_line =~ /^(?:q|quit)\s*$/);
 
+		check_database_handles({ anvil => $anvil }) or do {
+			pstderr("no usable database handle");
+
+			next;
+		}
+
 		my $pid = fork;
 
 		if (not defined $pid)
@@ -455,7 +496,13 @@ sub handle_connections
 		};
 
 		# clone the database handle for this child to avoid interfering with another process that needs to use the database
-		clone_database_handles({ anvil => $anvil });
+		clone_database_handles({ anvil => $anvil }) or do {
+			print $responder "failed to clone database handle(s)\n";
+
+			$responder->shutdown(SHUT_RDWR);
+
+			$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
+		}
 
 		my @cmd_lines = split(/;;/, $request_line);
 
@@ -487,6 +534,10 @@ sub handle_connections
 			elsif ($cmd_line =~ /^$scmd_execute\s+/)
 			{
 				process_scmd_execute({ anvil => $anvil, input => $cmd_line, lid => $cmd_line_id });
+			}
+			elsif ($cmd_line =~ /^$scmd_db_listen\s+/)
+			{
+				# it's a request to register a listener to a database trigger
 			}
 		}
 

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -164,9 +164,9 @@ my $running_directory   =  ($0 =~ /^(.*?)\/$THIS_FILE$/)[0];
 
 $running_directory =~ s/^\./$ENV{PWD}/ if $running_directory =~ /^\./ && $ENV{PWD};
 
-my $scmd_db_read   = "r";
-my $scmd_db_write  = "w";
-my $scmd_execute   = "x";
+my $scmd_db_read  = "r";
+my $scmd_db_write = "w";
+my $scmd_execute  = "x";
 
 main();
 

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -382,6 +382,84 @@ sub emit
 	pstdout("event=".$_[0]);
 }
 
+#
+# this subroutine should only run in the main process
+#
+sub fork_responder
+{
+	my $parameters = shift;
+	# required:
+	my $anvil      = $parameters->{anvil};
+	my $responder  = $parameters->{responder};
+	my $server     = $parameters->{server};
+
+	check_database_handles({ anvil => $anvil }) or do {
+		pstderr("no usable database handle");
+
+		return 0;
+	}
+
+	my $pid = fork;
+
+	if (not defined $pid)
+	{
+		pstderr("failed to fork on receive; cause: ".$!);
+
+		return 0;
+	}
+
+	if ($pid)
+	{
+		emit("responder:".$pid."-forked");
+
+		return 0;
+	}
+
+	#############
+	### BEGIN ### responder block
+	#############
+
+	# close the server because the child doesn't need it
+	close($server);
+
+	# disconnect from the parent's outputs to avoid interference
+
+	close(STDOUT);
+	close(STDERR);
+
+	# redirect outputs to the responder for transport
+
+	open(STDOUT, ">&", $responder) or do {
+		print $responder "failed to open STDOUT; cause: ".$!."\n";
+
+		$responder->shutdown(SHUT_RDWR);
+
+		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
+	};
+
+	open(STDERR, ">&", $responder) or do {
+		print $responder "failed to open STDERR; cause: ".$!."\n";
+
+		$responder->shutdown(SHUT_RDWR);
+
+		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
+	};
+
+	# clone the database handle for this child to avoid interfering with another process that needs to use the database
+	#
+	# the database handle variable only holds a reference to the parent's database handle before clone completes, therefore we shouldn't call disconnect unless clone succeeds
+
+	clone_database_handles({ anvil => $anvil }) or do {
+		print $responder "failed to clone database handle(s)\n";
+
+		$responder->shutdown(SHUT_RDWR);
+
+		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
+	}
+
+	return 1;
+}
+
 sub get_scmd_args
 {
 	my $parameters = shift;
@@ -414,12 +492,95 @@ sub get_scmd_args
 	return $args;
 }
 
+#
+# this subroutine should only run in the main process
+#
+sub manage_database_listeners
+{
+	my $parameters = shift;
+	# required:
+	my $anvil        = $parameters->{anvil};
+	my $db_listeners = $parameters->{db_listeners};
+	my $input        = $parameters->{input};
+	my $responder    = $parameters->{responder};
+	my $server       = $parameters->{server};
+
+	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { input => $input }, prefix => "manage_database_listeners" });
+
+	# ignore because it's not a database listener action
+	if (not ($input =~ s/^\s*dbl:://))
+	{
+		return 0;
+	}
+
+	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { input => $input } });
+
+	if ($input =~ s/^list//)
+	{
+		foreach my $trigger (sort { $a cmp $b } keys %{$db_listeners})
+		{
+			my $pid = $db_listeners->{$trigger};
+
+			pstdout($trigger.":".$pid);
+		}
+
+		return 1;
+	}
+
+	if ($input =~ s/^remove\s+(\d+)//)
+	{
+		my $pid = $1;
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { pid => $pid } });
+
+		kill 'TERM' $pid;
+
+		return 1;
+	}
+
+	if ($input =~ s/^add\s+(\w+)//)
+	{
+		my $trigger = $1;
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { trigger => $trigger } });
+
+		fork_responder({
+			anvil     => $anvil,
+			responder => $responder,
+			server    => $server,
+		}) or do {
+			return 1;
+		};
+
+		my $dbh;
+
+		foreach my $uuid (sort { $a cmp $b } keys %{$anvil->data->{database}})
+		{
+			$dbh = $anvil->data->{cache}{database_handle}{$uuid};
+
+			eval { $dbh->do("LISTEN ".$trigger); } and do {
+				last;
+			}
+		}
+
+		while (my $notify = eval { $dbh->pg_notifies; }) {
+			my ($name, $pid, $payload) = @$notify;
+
+			emit($name.":".$pid.":".$payload);
+		}
+
+		return 1;
+	}
+}
+
 sub handle_connections
 {
 	my $parameters = shift;
 	# required:
 	my $anvil      = $parameters->{anvil};
 	my $server     = $parameters->{server};
+
+	my $database_listeners = {};
 
 	local $SIG{INT}  = sub {
 		emit("sigint");
@@ -460,69 +621,31 @@ sub handle_connections
 
 		last if ($request_line =~ /^(?:q|quit)\s*$/);
 
-		check_database_handles({ anvil => $anvil }) or do {
-			pstderr("no usable database handle");
+		manage_database_listeners({
+			anvil        => $anvil,
+			db_listeners => $database_listeners,
+			input        => $request_line,
+			responder    => $responder,
+			server       => $server,
+		}) and do {
+			pstdout($$."::manage_database_listeners ended with true");
 
 			next;
-		}
-
-		my $pid = fork;
-
-		if (not defined $pid)
-		{
-			pstderr("failed to fork on receive; cause: ".$!);
-
-			next;
-		}
-
-		if ($pid)
-		{
-			emit("responder:".$pid."-forked");
-
-			next;
-		}
-
-		#############
-		### BEGIN ### responder block
-		#############
-
-		# close the server because the child doesn't need it
-		close($server);
-
-		# disconnect from the parent's outputs to avoid interference
-
-		close(STDOUT);
-		close(STDERR);
-
-		# redirect outputs to the responder for transport
-
-		open(STDOUT, ">&", $responder) or do {
-			print $responder "failed to open STDOUT; cause: ".$!."\n";
-
-			$responder->shutdown(SHUT_RDWR);
-
-			$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
 		};
 
-		open(STDERR, ">&", $responder) or do {
-			print $responder "failed to open STDERR; cause: ".$!."\n";
+		pstdout($$."::manage_database_listeners ended with false");
 
-			$responder->shutdown(SHUT_RDWR);
+		fork_responder({
+			anvil     => $anvil,
+			responder => $responder,
+			server    => $server,
+		}) or do {
+			pstdout($$."::fork_responder ended with false");
 
-			$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
+			next;
 		};
 
-		# clone the database handle for this child to avoid interfering with another process that needs to use the database
-		#
-		# the database handle variable only holds a reference to the parent's database handle before clone completes, therefore we shouldn't call disconnect unless clone succeeds
-
-		clone_database_handles({ anvil => $anvil }) or do {
-			print $responder "failed to clone database handle(s)\n";
-
-			$responder->shutdown(SHUT_RDWR);
-
-			$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
-		}
+		pstdout($$."::fork_responder ended with true");
 
 		my @cmd_lines = split(/;;/, $request_line);
 

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -496,6 +496,9 @@ sub handle_connections
 		};
 
 		# clone the database handle for this child to avoid interfering with another process that needs to use the database
+		#
+		# the database handle variable only holds a reference to the parent's database handle before clone completes, therefore we shouldn't call disconnect unless clone succeeds
+
 		clone_database_handles({ anvil => $anvil }) or do {
 			print $responder "failed to clone database handle(s)\n";
 
@@ -546,7 +549,7 @@ sub handle_connections
 
 		emit("responder:".$$."-exit");
 
-		$anvil->nice_exit({ db_disconnect => 0, exit_code => 0 });
+		$anvil->nice_exit({ exit_code => 0 });
 
 		#############
 		#### END #### responder block

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -154,6 +154,7 @@ use File::Spec::Functions;
 use File::Temp qw(tempdir);
 use IO::Socket::UNIX;
 use JSON;
+use Proc::Simple;
 use Text::ParseWords;
 
 $| = 1;
@@ -341,12 +342,15 @@ sub emit
 	pstdout("event=".$_[0]);
 }
 
-sub exit_responder
+#
+# this subroutine cleans up the fork made by fork_response_process()
+#
+sub exit_response_process
 {
 	my $parameters = shift;
 	# required:
-	my $anvil      = $parameters->{anvil};
-	my $responder  = $parameters->{responder};
+	my $anvil     = $parameters->{anvil};
+	my $responder = $parameters->{responder};
 
 	emit("responder:".$$."-exit");
 
@@ -356,15 +360,16 @@ sub exit_responder
 	$anvil->nice_exit({ exit_code => 0 });
 
 	#############
-	#### END #### responder block
+	#### END #### response process block
 	#############
 }
 
-# notes:
-# - this subroutine should only run in the main process
-# - every line after the call to this function are a part of the responder process
-# - calling this subroutine requires calling exit_responder later for clean up
-sub fork_responder
+#
+# this subroutine should only run in the main process
+#
+# every line after the call to this function are a part of the responder process
+#
+sub fork_response_process
 {
 	my $parameters = shift;
 	# required:
@@ -395,7 +400,7 @@ sub fork_responder
 	}
 
 	#############
-	### BEGIN ### responder block
+	### BEGIN ### response process block
 	#############
 
 	# close the server because the child doesn't need it
@@ -644,18 +649,22 @@ sub handle_connections
 		}) and do {
 			pstdout($$."::manage_database_listeners ended with true");
 
+			$responder->shutdown(SHUT_WR);
+
 			next;
 		};
 
 		pstdout($$."::manage_database_listeners ended with false");
 
-		fork_responder({ anvil => $anvil, responder => $responder, server => $server }) or do {
-			pstdout($$."::fork_responder ended with false");
+		fork_response_process({ anvil => $anvil, responder => $responder, server => $server }) or do {
+			pstdout($$."::fork_response_process ended with false");
+
+			$responder->shutdown(SHUT_WR);
 
 			next;
 		};
 
-		pstdout($$."::fork_responder ended with true");
+		pstdout($$."::fork_response_process ended with true");
 
 		my @cmd_lines = split(/;;/, $request_line);
 
@@ -690,7 +699,7 @@ sub handle_connections
 			}
 		}
 
-		exit_responder({ anvil => $anvil, responder => $responder });
+		exit_response_process({ anvil => $anvil, responder => $responder });
 	}
 
 	close($server);
@@ -717,9 +726,9 @@ sub main
 	$anvil->Get->switches;
 
 	my $daemonize   = $anvil->data->{switches}{'daemonize'}   // 0;
-	my $script_file = $anvil->data->{switches}{'script'}      // "-";
 	my $working_dir = $anvil->data->{switches}{'working-dir'} // cwd();
 
+	emit("pid:".$$);
 	emit("initialized");
 
 	$anvil->Database->connect({ auto_inactive_destroy => 1 });
@@ -761,187 +770,44 @@ sub main
 		$anvil->nice_exit({ exit_code => 1 });
 	};
 
-	# make child processes start-and-forget because we don't need to wait for them
+	# Make child processes start-and-forget because we don't need to wait for them
 	local $SIG{CHLD} = "IGNORE";
 
 	if ($daemonize)
 	{
+		# When running as daemon, the main process shouldn't do anything other than handling connections
 		handle_connections({ anvil => $anvil, server => $server });
-		# when running as daemon, the main process shouldn't do anything other than handling connections
-		return;
+
+		close($server);
+
+		$anvil->nice_exit({ exit_code => 0 });
 	}
 
-	# make 1 child to interact on stdio
-	my $interface_pid = fork;
+	my $interface_emitter = sub { emit("interface:".$$."-".$_[0]); };
 
-	if (not defined $interface_pid)
+	my $interface = Proc::Simple->new();
+
+	my $forked = $interface->start(\&run_interface, {
+		anvil       => $anvil,
+		emit        => $interface_emitter,
+		server      => $server,
+		socket_path => $socket_path,
+	});
+
+	if (not $forked)
 	{
-		pstderr("failed to fork IO interface; cause: ".$!);
+		pstderr("failed to fork IO interface; cause: ". $!);
 
 		close($server);
 
 		$anvil->nice_exit({ exit_code => 1 });
 	}
 
-	if ($interface_pid)
-	{
-		emit("interface:".$interface_pid."-forked");
+	$interface_emitter->("forked");
 
-		handle_connections({ anvil => $anvil, server => $server });
-		# after starting a child process to handle the stdin interactions, the main process should only handle connections
-		return;
-	}
+	handle_connections({ anvil => $anvil, server => $server });
 
-	#############
-	### BEGIN ### interface block
-	#############
-
-	# close the server because the child doesn't need it
-	close($server);
-
-	my $script_file_handle;
-
-	local $SIG{INT}  = sub {
-		emit("interface:".$$."-sigint");
-
-		close($script_file_handle);
-
-		emit("interface:".$$."-exit");
-
-		$anvil->catch_sig({ signal => "INT" });
-	};
-
-	local $SIG{TERM} = sub {
-		emit("interface:".$$."-sigterm");
-
-		close($script_file_handle);
-
-		emit("interface:".$$."-exit");
-
-		$anvil->catch_sig({ signal => "TERM" });
-	};
-
-	eval {
-		# TODO: make this script read piped input
-
-		$script_file = "-" if ($script_file =~ /^#!SET!#$/);
-
-		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { script_file => $script_file } });
-
-		if ($script_file =~ /^-$/)
-		{
-			open($script_file_handle, "-");
-		}
-		else
-		{
-			open($script_file_handle, "< :encoding(UTF-8)", $script_file);
-		}
-	} or do {
-		# open() sets $! upon error, different from the database module failure (which sets $@)
-		pstderr("failed to open ".$script_file." as script input; cause: ".$!);
-
-		$anvil->nice_exit({ exit_code => 1 });
-	};
-
-	emit("interface:".$$."-ready");
-
-	while (my $script_line = <$script_file_handle>)
-	{
-		chomp($script_line);
-
-		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { script_line => $script_line } });
-
-		if ($script_line =~ /^(?:q|quit)\s*$/)
-		{
-			my $quitter = IO::Socket::UNIX->new(
-				Peer => $socket_path,
-				Type => SOCK_STREAM,
-			) or do {
-				pstderr("failed to create QUIT connection to ".$socket_path."; cause: $@");
-
-				$anvil->nice_exit({ exit_code => 1 });
-			};
-
-			print $quitter $script_line;
-
-			$quitter->shutdown(SHUT_RDWR);
-
-			last;
-		}
-
-		my $pid = fork; # the child process starts here when spawned successfully:
-
-		# - fork returns `undef` when it fails to spawn the child
-		# - fork returns the child's pid to the parent
-		# - fork returns `0` to the child
-
-		if (not defined $pid) {
-			pstderr("failed to fork on send; cause: ".$!);
-
-			next;
-		}
-
-		if ($pid)
-		{
-			emit("requester:".$pid."-forked");
-
-			next;
-		}
-
-		#############
-		### BEGIN ### requester block
-		#############
-
-		# the child doesn't need to process input
-		close($script_file_handle);
-
-		my $requester = IO::Socket::UNIX->new(
-			Peer => $socket_path,
-			Type => SOCK_STREAM,
-		) or do {
-			pstderr("failed to create connection to ".$socket_path."; cause: ".$@);
-
-			$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
-		};
-
-		print $requester $script_line;
-
-		$requester->shutdown(SHUT_WR);
-
-		while (my $line = <$requester>)
-		{
-			chomp($line);
-
-			eval {
-				my $decoded = decode_json($line);
-				my $encoded = JSON->new->utf8->allow_blessed->pretty->encode($decoded);
-
-				pstdout($encoded);
-			} or do {
-				pstdout($line);
-			}
-		}
-
-		$requester->shutdown(SHUT_RD);
-
-		emit("requester:".$$."-exit");
-
-		$anvil->nice_exit({ db_disconnect => 0, exit_code => 0 });
-
-		#############
-		#### END #### requester block
-		#############
-	}
-
-	close($script_file_handle);
-
-	emit("interface:".$$."-exit");
-
-	$anvil->nice_exit({ db_disconnect => 0, exit_code => 0 });
-
-	#############
-	#### END #### interface block
-	#############
+	$anvil->nice_exit({ exit_code => 0 });
 }
 
 sub prettify
@@ -1064,4 +930,168 @@ sub pstdout
 sub pstderr
 {
 	print STDERR "error: ".$_[0]."\n" if defined $_[0];
+}
+
+sub run_interface
+{
+	my $parameters  = shift;
+	# Required:
+	my $anvil       = $parameters->{anvil};
+	my $emit        = $parameters->{emit};
+	my $server      = $parameters->{server};
+	my $socket_path = $parameters->{socket_path};
+
+	return (0) if (not $anvil);
+	return (0) if (not $server);
+
+	my $script_file = $anvil->data->{switches}{'script'} // "-";
+
+	# Close the server because the child doesn't need it.
+	close($server);
+
+	my $script_file_handle;
+
+	# Setup custom signal handlers for the child process.
+
+	local $SIG{INT}  = sub {
+		$emit->("sigint");
+
+		close($script_file_handle);
+
+		$emit->("exit");
+
+		$anvil->catch_sig({ signal => "INT" });
+	};
+
+	local $SIG{TERM} = sub {
+		$emit->("sigterm");
+
+		close($script_file_handle);
+
+		$emit->("exit");
+
+		$anvil->catch_sig({ signal => "TERM" });
+	};
+
+	eval {
+		# TODO: make this script read piped input.
+
+		$script_file = "-" if ($script_file =~ /^#!SET!#$/);
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { script_file => $script_file } });
+
+		if ($script_file =~ /^-$/)
+		{
+			open($script_file_handle, "-");
+		}
+		else
+		{
+			open($script_file_handle, "< :encoding(UTF-8)", $script_file);
+		}
+	} or do {
+		# open() sets $! upon error, different from the database module failure (which sets $@).
+		pstderr("failed to open ".$script_file." as script input; cause: ".$!);
+
+		$anvil->nice_exit({ exit_code => 1 });
+	};
+
+	$emit->("ready");
+
+	while (my $script_line = <$script_file_handle>)
+	{
+		chomp($script_line);
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { script_line => $script_line } });
+
+		if ($script_line =~ /^(?:q|quit)\s*$/)
+		{
+			my $quitter = IO::Socket::UNIX->new(
+				Peer => $socket_path,
+				Type => SOCK_STREAM,
+			) or do {
+				pstderr("failed to create QUIT connection to ".$socket_path."; cause: $@");
+
+				$anvil->nice_exit({ exit_code => 1 });
+			};
+
+			print $quitter $script_line;
+
+			$quitter->shutdown(SHUT_RDWR);
+
+			last;
+		}
+
+		local $requester_emitter = sub { emit("requester:".$$."-".$_[0]); };
+
+		my $requester = Proc::Simple->new();
+
+		$requester->start(\&run_requester, {
+			anvil       => $anvil,
+			emit        => $requester_emitter,
+			script_fh   => $script_file_handle,
+			script_line => $script_line,
+			socket_path => $socket_path,
+		});
+
+		$requester_emitter->("forked");
+	}
+
+	close($script_file_handle);
+
+	$emit->("exit");
+
+	$anvil->nice_exit({ exit_code => 0 });
+}
+
+sub run_requester
+{
+	my $parameters  = shift;
+	# Required:
+	my $anvil       = $parameters->{anvil};
+	my $emit        = $parameters->{emit};
+	my $script_fh   = $parameters->{script_fh};
+	my $script_line = $parameters->{script_line};
+	my $socket_path = $parameters->{socket_path};
+
+	return (0) if (not $anvil);
+	return (0) if (not $script_fh);
+
+	# The child doesn't need to process input.
+	close($script_fh);
+
+	my $requester = IO::Socket::UNIX->new(
+		Peer => $socket_path,
+		Type => SOCK_STREAM,
+	) or do {
+		pstderr("failed to create connection to ".$socket_path."; cause: ".$@);
+
+		# We're not using the database connection(s) here; it's not cloned.
+		# The cache is pointing to the main process's connection(s); don't close it.
+		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
+	};
+
+	print $requester $script_line;
+
+	$requester->shutdown(SHUT_WR);
+
+	while (my $line = <$requester>)
+	{
+		chomp($line);
+
+		eval {
+			my $decoded = decode_json($line);
+			my $encoded = JSON->new->utf8->allow_blessed->pretty->encode($decoded);
+
+			pstdout($encoded);
+		} or do {
+			pstdout($line);
+		}
+	}
+
+	$requester->shutdown(SHUT_RD);
+
+	$emit->("exit");
+
+	# Same; don't close because the cache is pointing to the original connection(s).
+	$anvil->nice_exit({ db_disconnect => 0, exit_code => 0 });
 }

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -296,52 +296,6 @@ sub check_database_handles
 	return $success;
 }
 
-# only used by child processes to clone the parent's database handles
-sub clone_database_handles
-{
-	my $parameters = shift;
-	my $anvil      = $parameters->{anvil};
-
-	my $success = 0;
-
-	foreach my $uuid (sort { $a cmp $b } keys %{$anvil->data->{database}})
-	{
-		# get the copied parent's database handle, which was made when fork()
-		my $dbh = $anvil->data->{cache}{database_handle}{$uuid};
-
-		# release the reference to the copied parent's dbh; this will not close the parent's original database handle because auto_inactive_destroy is set
-		undef $anvil->data->{cache}{database_handle}{$uuid};
-
-		my $child_dbh;
-
-		# clone the parent's database handle for child use
-		my $cloned = eval { $child_dbh = $dbh->clone(); };
-
-		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
-			database_uuid => $uuid,
-			dbh_local     => $dbh,
-			dbh_cache     => $anvil->data->{cache}{database_handle}{$uuid},
-			cloned        => $cloned,
-			dbh_child     => $child_dbh,
-		} });
-
-		if (not $cloned)
-		{
-			# failed to clone the parent's database handle; skip it
-			next;
-		}
-
-		# add the cloned child's dbh
-		$anvil->data->{cache}{database_handle}{$uuid} = $child_dbh;
-
-		$success += 1;
-	}
-
-	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { success => $success }, prefix => "clone_database_handles" });
-
-	return $success;
-}
-
 sub db_access
 {
 	my $parameters = shift;
@@ -447,40 +401,18 @@ sub fork_responder
 	# close the server because the child doesn't need it
 	close($server);
 
-	# disconnect from the parent's outputs to avoid interference
-
-	close(STDOUT);
-	close(STDERR);
-
-	# redirect outputs to the responder for transport
-
-	open(STDOUT, ">&", $responder) or do {
-		print $responder "failed to open STDOUT; cause: ".$!."\n";
-
-		$responder->shutdown(SHUT_RDWR);
-
-		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
-	};
-
-	open(STDERR, ">&", $responder) or do {
-		print $responder "failed to open STDERR; cause: ".$!."\n";
-
-		$responder->shutdown(SHUT_RDWR);
-
-		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
-	};
+	handle_responder_output_setup({ anvil => $anvil, responder => $responder });
 
 	# clone the database handle for this child to avoid interfering with another process that needs to use the database
 	#
 	# the database handle variable only holds a reference to the parent's database handle before clone completes, therefore we shouldn't call disconnect unless clone succeeds
 
-	clone_database_handles({ anvil => $anvil }) or do {
-		print $responder "failed to clone database handle(s)\n";
+	my ($clone_connection_code, $clone) = $anvil->Database->clone_connection({ debug => 2 });
 
-		$responder->shutdown(SHUT_RDWR);
-
-		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
-	};
+	if (not $clone)
+	{
+		handle_database_clone_connection_failure({ anvil => $anvil, responder => $responder });
+	}
 
 	return 1;
 }
@@ -567,29 +499,88 @@ sub manage_database_listeners
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { trigger => $trigger } });
 
-		fork_responder({ anvil => $anvil, responder => $responder, server => $server }) or do {
-			return 1;
+		my $clone_fail_handler = \&handle_database_clone_connection_failure;
+
+		my $fork_child_handler = sub {
+			# close the server because the child doesn't need it
+			close($server);
+
+			handle_responder_output_setup({ anvil => $anvil, responder => $responder });
+		}
+
+		my $notify_handler = sub {
+			my $params = shift;
+			my $notify = $params->{notify};
+
+			my ($n_name, $n_pid, $n_payload) = @$notify;
+
+			emit($n_name.":".$n_pid.":".$n_payload);
 		};
 
-		my $dbh;
+		my ($add_listener_code, $pid, $error) = $anvil->Database->add_listener({
+			debug            => 2,
+			name             => $trigger,
+			on_clone_fail    => $clone_fail_handler,
+			on_fork_child    => $fork_child_handler,
+			on_notify        => $notify_handler,
+		});
 
-		foreach my $uuid (sort { $a cmp $b } keys %{$anvil->data->{database}})
+		if ($add_listener_code != 0)
 		{
-			$dbh = $anvil->data->{cache}{database_handle}{$uuid};
+			pstdout("failed to fork on receive; cause: ".$error);
 
-			eval { $dbh->do("LISTEN ".$trigger); } and do {
-				last;
-			}
+			return 0;
 		}
 
-		while (my $notify = eval { $dbh->pg_notifies; }) {
-			my ($name, $pid, $payload) = @$notify;
+		emit("db-listener:".$pid."-forked");
 
-			emit($name.":".$pid.":".$payload);
-		}
-
-		exit_responder({ anvil => $anvil, responder => $responder });
+		return 1;
 	}
+}
+
+sub handle_database_clone_connection_failure
+{
+	my $parameters = shift;
+	# required:
+	my $anvil      = $parameters->{anvil};
+	my $responder  = $parameters->{responder};
+
+	print $responder "failed to clone primary database handle\n";
+
+	$responder->shutdown(SHUT_RDWR);
+
+	$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
+}
+
+sub handle_responder_output_setup
+{
+	my $parameters = shift;
+	# required:
+	my $anvil      = $parameters->{anvil};
+	my $responder  = $parameters->{responder};
+
+	# disconnect from the parent's outputs to avoid interference
+
+	close(STDOUT);
+	close(STDERR);
+
+	# redirect outputs to the responder for transport
+
+	open(STDOUT, ">&", $responder) or do {
+		print $responder "failed to open STDOUT; cause: ".$!."\n";
+
+		$responder->shutdown(SHUT_RDWR);
+
+		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
+	};
+
+	open(STDERR, ">&", $responder) or do {
+		print $responder "failed to open STDERR; cause: ".$!."\n";
+
+		$responder->shutdown(SHUT_RDWR);
+
+		$anvil->nice_exit({ db_disconnect => 0, exit_code => 1 });
+	};
 }
 
 sub handle_connections

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -268,11 +268,16 @@ sub check_database_handles
 	my $parameters = shift;
 	my $anvil      = $parameters->{anvil};
 
-	my $success_count = 0;
+	my $success = 0;
 
 	foreach my $uuid (sort { $a cmp $b } keys %{$anvil->data->{database}})
 	{
 		my $dbh = $anvil->data->{cache}{database_handle}{$uuid};
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+			database_uuid => $uuid,
+			dbh_local     => $dbh,
+		} });
 
 		if ((not exists $dbh) or (not $dbh) or (not $dbh->ping))
 		{
@@ -280,10 +285,12 @@ sub check_database_handles
 			next;
 		}
 
-		$success_count += 1;
+		$success += 1;
 	}
 
-	return $success_count;
+	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { success => $success }, prefix => "check_database_handles" });
+
+	return $success;
 }
 
 # only used by child processes to clone the parent's database handles
@@ -292,33 +299,44 @@ sub clone_database_handles
 	my $parameters = shift;
 	my $anvil      = $parameters->{anvil};
 
-	my $success_count = 0;
+	my $success = 0;
 
 	foreach my $uuid (sort { $a cmp $b } keys %{$anvil->data->{database}})
 	{
 		# get the copied parent's database handle, which was made when fork()
 		my $dbh = $anvil->data->{cache}{database_handle}{$uuid};
 
+		# release the reference to the copied parent's dbh; this will not close the parent's original database handle because auto_inactive_destroy is set
+		undef $anvil->data->{cache}{database_handle}{$uuid};
+
 		my $child_dbh;
 
 		# clone the parent's database handle for child use
-		my $success = eval { $child_dbh = $dbh->clone(); };
+		my $cloned = eval { $child_dbh = $dbh->clone(); };
 
-		if (not $success)
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+			database_uuid => $uuid,
+			dbh_local     => $dbh,
+			dbh_cache     => $anvil->data->{cache}{database_handle}{$uuid},
+			cloned        => $cloned,
+			dbh_child     => $child_dbh,
+		} });
+
+		if (not $cloned)
 		{
 			# failed to clone the parent's database handle; skip it
 			next;
 		}
 
-		# destroy the copied parent's dbh; this will not close the parent's original database handle because auto_inactive_destroy is set
-		undef $anvil->data->{cache}{database_handle}{$uuid};
 		# add the cloned child's dbh
 		$anvil->data->{cache}{database_handle}{$uuid} = $child_dbh;
 
-		$success_count += 1;
+		$success += 1;
 	}
 
-	return $success_count;
+	$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { success => $success }, prefix => "clone_database_handles" });
+
+	return $success;
 }
 
 sub db_access

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -271,6 +271,11 @@ sub check_database_handles
 
 	foreach my $uuid (sort { $a cmp $b } keys %{$anvil->data->{database}})
 	{
+		if (not exists $anvil->data->{cache}{database_handle}{$uuid})
+		{
+			next;
+		}
+
 		my $dbh = $anvil->data->{cache}{database_handle}{$uuid};
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
@@ -278,7 +283,7 @@ sub check_database_handles
 			dbh_local     => $dbh,
 		} });
 
-		if ((not exists $dbh) or (not $dbh) or (not $dbh->ping))
+		if ((not $dbh) or (not $dbh->ping))
 		{
 			next;
 		}

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -685,10 +685,10 @@ sub handle_connections
 			}
 		}
 
+		emit("responder:".$$."-exit");
+
 		# responder is done writing
 		$responder->shutdown(SHUT_WR);
-
-		emit("responder:".$$."-exit");
 
 		$anvil->nice_exit({ exit_code => 0 });
 

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -538,7 +538,7 @@ sub manage_database_listeners
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { pid => $pid } });
 
-		kill 'TERM' $pid;
+		kill('TERM', $pid);
 
 		return 1;
 	}

--- a/tools/anvil-access-module
+++ b/tools/anvil-access-module
@@ -523,7 +523,7 @@ sub main
 
 	if (not $daemonize)
 	{
-		my $emit_interface_event = sub { emit("interface:".$$."-".$_[0]); };
+		my $emit_interface_event = sub { emit("interface:".($_[1] // $$)."-".$_[0]); };
 
 		my $interface_process = Proc::Simple->new();
 
@@ -540,7 +540,7 @@ sub main
 			$anvil->nice_exit({ exit_code => 1 });
 		};
 
-		$emit_interface_event->("forked");
+		$emit_interface_event->("forked", $interface_process->pid);
 	}
 
 	local $SIG{INT}  = sub {
@@ -636,8 +636,6 @@ sub manage_database_listeners
 
 		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { name => $name } }); 
 
-
-
 		my ($add_listener_code, $pid, $error) = $anvil->Database->add_listener({
 			debug              => 2,
 			name               => $name,
@@ -665,7 +663,7 @@ sub manage_database_listeners
 			return 0;
 		}
 
-		$emit->("forked");
+		$emit->("forked", $pid);
 
 		return 1;
 	}

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -514,7 +514,11 @@ sub handle_periodic_tasks
 		
 		# This checks to see if the strikers in the DB are also in anvil.conf
 		check_strikers($anvil);
-		
+
+		# Check if the job listener is alive, try spawning it if not.
+		# Let the next minute try again if the spawn fails.
+		spawn_job_listener($anvil) if (not check_job_listener($anvil));
+
 		# Do Striker-specific minute tasks
 		$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { host_type => $host_type }});
 		if ($host_type eq "striker")
@@ -1422,7 +1426,10 @@ sub run_once
 	
 	# Make sure we don't spam the hell out of the console with network manager messages on boot
 	check_sysctl($anvil);
-	
+
+	# Start listening for jobs.
+	spawn_job_listener($anvil);
+
 	if ($anvil->data->{switches}{'startup-only'})
 	{
 		$anvil->nice_exit({exit_code => 0});
@@ -1964,7 +1971,7 @@ AND
 	handle_special_cases($anvil);
 	
 	# Now look for jobs that have a job status of 'anvil_startup'
-	run_jobs($anvil, 1);
+	run_jobs($anvil, { startup => 1 });
 	
 	# Check to make sure that we don't have conflicts with the Striker WebUI
 	check_for_conflicting_web_ports($anvil);
@@ -2094,7 +2101,7 @@ sub keep_running
 	}
 	
 	# Run any pending jobs by calling 'anvil-jobs' with the 'job_uuid' as a background process.
-	run_jobs($anvil, 0);
+	run_jobs($anvil);
 	
 	return(0);
 }
@@ -2104,8 +2111,16 @@ sub keep_running
 # invoked to handle it.
 sub run_jobs
 {
-	my ($anvil, $startup) = @_;
-	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { startup => $startup }});
+	my $anvil      = shift;
+	my $parameters = shift;
+	# Specifies whether we're in the main process, which needs to make way for the database listener to avoid race conditions.
+	my $in_main    = $parameters->{in_main} // 1;
+	my $startup    = $parameters->{startup} // 0;
+
+	$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => {
+		in_main => $in_main,
+		startup => $startup,
+	}});
 	
 	# Don't start jobs for 30 seconds after startup.
 	if (not $startup)
@@ -2181,7 +2196,16 @@ sub run_jobs
 				's13:started_seconds_ago'  => $started_seconds_ago, 
 				's14:updated_seconds_ago'  => $updated_seconds_ago, 
 			}});
-			
+
+			# Let the database listener pick up jobs first, then let the main process pick up any leftovers.
+			if (($in_main) and (not $anvil->data->{seen_jobs}{$job_uuid}))
+			{
+				# We haven't seen this job, mark it as seen but don't process it.
+				$anvil->data->{seen_jobs}{$job_uuid} = 1;
+
+				next;
+			}
+
 			# If we're not configured, we will only run the 'anvil-configure-host' job
 			my $configured = $anvil->System->check_if_configured;
 			$anvil->Log->variables({source => $THIS_FILE, line => __LINE__, level => 2, list => { configured => $configured }});
@@ -2235,6 +2259,9 @@ sub run_jobs
 					job_picked_up_by             => $job_picked_up_by, 
 					"jobs::${job_uuid}::started" => $anvil->data->{jobs}{$job_uuid}{started},
 				}});
+
+				# Clean up the "seen" flag for this completed job.
+				delete $anvil->data->{seen_jobs}{$job_uuid} if ($in_main);
 			}
 			else
 			{
@@ -2589,4 +2616,82 @@ sub check_files
 	$anvil->Storage->check_files({debug => 2});
 	
 	return(0);
+}
+
+sub check_job_listener
+{
+	my $anvil = shift;
+
+	my $listeners = $anvil->Database->{listeners}{"after_insert_or_update_job"};
+
+	my $count = 0;
+
+	# Loop through job listeners only, there should only be 1.
+	foreach my $pid (key %{$listeners})
+	{
+		my $listener = $listeners->{$pid};
+
+		if ($listener->poll())
+		{
+			# Adjust the return code, any greater than 0 is a pass.
+			$count += 1;
+		}
+		else
+		{
+			# The job listener was found dead during a periodic check, dispose the remains.
+			delete $listeners->{$pid};
+			# Beat it just to make sure it's actually dead.
+			$listener->kill() or $listener->kill("SIGKILL");
+		}
+	}
+
+	return ($count);
+}
+
+sub spawn_job_listener
+{
+	my $anvil = shift;
+
+	my $handle_notify = sub {
+		my $params = shift;
+		my $notify = $params->{notify};
+
+		my ($name, $pid, $payload) = @$notify;
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => {
+			name    => $name,
+			pid     => $pid,
+			payload => $payload,
+		}, prefix => "handle_notify" });
+
+		my $job = eval { decode_json($payload); };
+
+		$anvil->Log->variables({ source => $THIS_FILE, line => __LINE__, level => 2, list => { job => $job } });
+
+		if (not $job)
+		{
+			# Ignore job(s) with malformed payload.
+			return (0);
+		}
+
+		if ($job->{job_progress} != 0)
+		{
+			# Ignore running or finished job(s).
+			return (0);
+		}
+
+		run_jobs($anvil, { in_main => 0 });
+	};
+
+	my ($add_listener_code, $listener, $error) = $anvil->Database->add_listener({
+		name      => "after_insert_or_update_job",
+		on_notify => $handle_notify,
+	});
+
+	if ($add_listener_code != 0)
+	{
+		return (0, undef, $error);
+	}
+
+	return (1, $listener);
 }

--- a/tools/anvil-daemon
+++ b/tools/anvil-daemon
@@ -2627,7 +2627,7 @@ sub check_job_listener
 	my $count = 0;
 
 	# Loop through job listeners only, there should only be 1.
-	foreach my $pid (key %{$listeners})
+	foreach my $pid (keys %{$listeners})
 	{
 		my $listener = $listeners->{$pid};
 

--- a/tools/anvil-version-changes
+++ b/tools/anvil-version-changes
@@ -108,7 +108,10 @@ sub striker_checks
 
 	# This adds notes to storage_group_members
 	update_host_variables($anvil);
-	
+
+	# Change the trigger of the jobs table to include the notify call.
+	update_jobs_trigger($anvil);
+
 	return(0);
 }
 
@@ -857,6 +860,58 @@ CREATE TRIGGER trigger_host_variables
 			}
 			$anvil->Database->write({debug => 2, uuid => $uuid, query => $queries, source => $THIS_FILE, line => __LINE__});
 		}
+	}
+
+	return(0);
+}
+
+sub update_jobs_trigger
+{
+	my ($anvil) = @_;
+
+	foreach my $uuid (sort {$a cmp $b} keys %{$anvil->data->{cache}{database_handle}})
+	{
+		my $sql = q|CREATE OR REPLACE FUNCTION history_jobs() RETURNS trigger
+AS $$
+DECLARE
+    history_jobs RECORD;
+BEGIN
+    SELECT INTO history_jobs * FROM jobs WHERE job_uuid = NEW.job_uuid;
+    INSERT INTO history.jobs
+        (job_uuid,
+         job_host_uuid,
+         job_command,
+         job_data,
+         job_picked_up_by,
+         job_picked_up_at,
+         job_updated,
+         job_name,
+         job_progress,
+         job_title,
+         job_description,
+         job_status,
+         modified_date)
+    VALUES
+        (history_jobs.job_uuid,
+         history_jobs.job_host_uuid,
+         history_jobs.job_command,
+         history_jobs.job_data,
+         history_jobs.job_picked_up_by,
+         history_jobs.job_picked_up_at,
+         history_jobs.job_updated,
+         history_jobs.job_name,
+         history_jobs.job_progress,
+         history_jobs.job_title,
+         history_jobs.job_description,
+         history_jobs.job_status,
+         history_jobs.modified_date);
+    PERFORM pg_notify('after_insert_or_update_job', row_to_json(NEW)::text);
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+|;
+		$anvil->Database->write({debug => 2, uuid => $uuid, query => $sql, source => $THIS_FILE, line => __LINE__});
 	}
 
 	return(0);


### PR DESCRIPTION
This PR contains the foundation work for #801.

Changes:
- The database will notify when the jobs table gets an insert or update change.
- The database perl module will have the basic methods for managing the database listeners which can receive and react to the notify calls from the database.
- `anvil-daemon` will react to notify calls triggered by the jobs table.
- `anvil-access-module` will use Proc::Simple as a replacement for `fork()` to keep the code base cleaner.

Additional thoughts:
The functions provided in `anvil-access-module` to manage database listeners may not be needed since the listener-related logic was moved to the database perl module. But it's kept in place for convenience.

If more control is required, try using the methods directly with JSON as parameters, like: `x Database->add_listener '{"param1":"value1",...}'`